### PR TITLE
Algolia Search Bar

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -128,7 +128,7 @@ const config = {
         contextualSearch: true,
 
         // Optional: Specify domains where the navigation should occur through window.location instead on history.push. Useful when our Algolia config crawls multiple documentation sites and we want to navigate with window.location.href to them.
-        externalUrlRegex: 'docs\\.dbos\\.dev',
+        // externalUrlRegex: 'docs\\.dbos\\.dev',
 
         // Optional: Replace parts of the item URLs from Algolia. Useful when using the same search index for multiple deployments using a different baseUrl. You can use regexp or string in the `from` param. For example: localhost:3000 vs myCompany.com/docs
         // replaceSearchResultPathname: {


### PR DESCRIPTION
This PR adds a search bar to our docs, which is powered by Algolia.
The crawler runs every week, but we can also manually refresh it whenever we publish our docs.

We are currently using the free plan, but we can upgrade later to use more powerful search/recommendation.

Please let me know if you want to access the Algolia dash board.

A screenshot of how it looks like:
![image](https://github.com/dbos-inc/dbos-docs/assets/11331727/112e7a7f-ad55-4659-a5a3-d9361742b5a9)
