### PR TITLE
configure docusaurus to remove trailing slahses in URLs

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -13,6 +13,8 @@ const config = {
   // For GitHub pages deployment, it is often '/<projectName>/'
   baseUrl: '/',
 
+  trailingSlash: false,
+
   // GitHub pages deployment config.
   // If you aren't using GitHub pages, you don't need these.
   organizationName: 'dbos-inc', // Usually your GitHub org/user name.
@@ -161,12 +163,12 @@ const config = {
 
         //... other Algolia params
       },
-    matomo: {
-      matomoUrl: 'https://dbosdev.matomo.cloud/',
-      siteId: '1',
-      phpLoader: 'matomo.php',
-      jsLoader: 'matomo.js',
-    },
+      matomo: {
+        matomoUrl: 'https://dbosdev.matomo.cloud/',
+        siteId: '1',
+        phpLoader: 'matomo.php',
+        jsLoader: 'matomo.js',
+      },
     }),
 };
 


### PR DESCRIPTION
URLs returned by algolia search have a trailing slash.

This breaks our links, e.g., `../tutorials/workflow-communication-tutorial` would not work from an URL with a trailing slash, it would require two hops (`../..`)


Example of an URL accessed from the search without this change:

![Screenshot 2024-03-29 at 11 36 52](https://github.com/dbos-inc/dbos-docs/assets/3437048/30b2b3c1-3385-4da4-b8b3-de95d59186fc)


With this change

![Screenshot 2024-03-29 at 11 36 28](https://github.com/dbos-inc/dbos-docs/assets/3437048/bd37b74f-f64a-4b5e-8ca3-364e74dbc8f1)

