### PR TITLE
fix(workflow-tutorial): add a 'y' to 'an'

### DIFF
--- a/docs/tutorials/workflow-tutorial.md
+++ b/docs/tutorials/workflow-tutorial.md
@@ -63,7 +63,7 @@ These guarantees assume that the application and database may crash and go offli
 2.  Transactions commit _exactly once_.  Once a workflow commits a transaction, it will never retry that transaction.
 3.  Communicators are tried _at least once_ but are never re-executed after they successfully complete.  If a failure occurs inside a communicator, the communicator may be retried, but once a communicator has completed, it will never be re-executed.
 
-For safety, DBOS automatically attempts to recover any workflow a set number of times.
+For safety, DBOS automatically attempts to recover a workflow a set number of times.
 If a workflow exceeds this limit, its status is set to `RETRIES_EXCEEDED` and it is no longer retried automatically, though it may be [retried manually](#workflow-management).
 This acts as a [dead letter queue](https://en.wikipedia.org/wiki/Dead_letter_queue) so that a buggy workflow that crashes its application (for example, by running it out of memory) is not retried infinitely.
 The maximum number of retries is by default 50, but this may be configured through arguments to the [`@Workflow`](../api-reference/decorators.md#workflow) decorator.

--- a/docs/tutorials/workflow-tutorial.md
+++ b/docs/tutorials/workflow-tutorial.md
@@ -63,7 +63,7 @@ These guarantees assume that the application and database may crash and go offli
 2.  Transactions commit _exactly once_.  Once a workflow commits a transaction, it will never retry that transaction.
 3.  Communicators are tried _at least once_ but are never re-executed after they successfully complete.  If a failure occurs inside a communicator, the communicator may be retried, but once a communicator has completed, it will never be re-executed.
 
-For safety, DBOS automatically attempts to recover an workflow a set number of times.
+For safety, DBOS automatically attempts to recover any workflow a set number of times.
 If a workflow exceeds this limit, its status is set to `RETRIES_EXCEEDED` and it is no longer retried automatically, though it may be [retried manually](#workflow-management).
 This acts as a [dead letter queue](https://en.wikipedia.org/wiki/Dead_letter_queue) so that a buggy workflow that crashes its application (for example, by running it out of memory) is not retried infinitely.
 The maximum number of retries is by default 50, but this may be configured through arguments to the [`@Workflow`](../api-reference/decorators.md#workflow) decorator.


### PR DESCRIPTION
### Description

I was reading the docs this morning and noticed a small typo. This PR aims to fix it. My goal is to contribute the smallest change in the entire history of this project. 😤

> Please note: I don't know if this was the original intent of the author. It's possible that they want to make it  "...DBOS attempt to recover _a_ workflow..."