### PR TITLE
Optional time travel

### DIFF
--- a/docs/api-reference/cloud-cli.md
+++ b/docs/api-reference/cloud-cli.md
@@ -161,7 +161,7 @@ This feature is currently only available to [DBOS Pro or Enterprise](https://www
 - `-H, --hostname <string>`: The hostname for your Postgres database instance (required).
 - `-p, --port [number]`: The connection port for your Postgres database instance (default: `5432`).
 - `-W, --password [string]`: The password for the `dbosadmin` role. If not provided, will be prompted on the command line. Passwords must contain 8 or more characters.
-- `--enable-timetravel`: Enable time travel for your database instance. Please follow [our instructions](../cloud-tutorials/byod-management#enabling-time-travel) to set up your database before using this option.
+- `--enable-timetravel`: Enable time travel for your database instance. If you are using a linked database, please follow [our instructions](../cloud-tutorials/byod-management#enabling-time-travel) to set up your database before using this option.
 
 ---
 
@@ -186,6 +186,7 @@ It registers that application with DBOS Cloud.
 **Parameters:**
 - `[application-name]`: The name of the application to register. By default we obtain the application name from package.json. This argument overrides the package name.
 - `-d, --database <string>`: The name of the Postgres database instance to which this application will connect.
+- `--enable-timetravel`: Enable time travel for this application. Please follow [our instructions](../cloud-tutorials/byod-management#enabling-time-travel) to set up your database before using this option.
 
 ---
 

--- a/docs/api-reference/system-tables.md
+++ b/docs/api-reference/system-tables.md
@@ -64,7 +64,7 @@ This table stores the outputs of communicator functions:
 ## Provenance Tables
 
 :::tip
-Time travel is disabled by default. The provenance database is only available for applications configured to enable time travel. To enable time travel for your application, please specify `--enable-timetravel` [during registration](./cloud-cli#npx-dbos-cloud-app-register).
+The provenance database is only available for applications configured to enable time travel. To enable time travel for your application, please specify `--enable-timetravel` [during registration](./cloud-cli#npx-dbos-cloud-app-register).
 :::
 
 DBOS Cloud maintains a provenance database for your application, which is an append-only versioned replica of your application database.

--- a/docs/api-reference/system-tables.md
+++ b/docs/api-reference/system-tables.md
@@ -63,6 +63,10 @@ This table stores the outputs of communicator functions:
 
 ## Provenance Tables
 
+:::tip
+Time travel is disabled by default. The provenance database is only available for applications configured to enable time travel. To enable time travel for your application, please specify `--enable-timetravel` [during registration](./cloud-cli#npx-dbos-cloud-app-register).
+:::
+
 DBOS Cloud maintains a provenance database for your application, which is an append-only versioned replica of your application database.
 It is the key enabler of [Interactive Time Travel](../cloud-tutorials/interactive-timetravel.md) and [Time Travel Debugging](../cloud-tutorials/timetravel-debugging.md).
 The provenance database name is your application database suffixed with `_dbos_prov`.

--- a/docs/cloud-tutorials/application-management.md
+++ b/docs/cloud-tutorials/application-management.md
@@ -25,7 +25,7 @@ Your application is automatically registered under the name in its `package.json
 Application names should be between 3 and 30 characters and must contain only lowercase letters and numbers, dashes (`-`), and underscores (`_`).
 
 :::tip
-Time travel is disabled by default. To enable time travel for your application, please specify `--enable-timetravel` when you [register your application](../api-reference/cloud-cli#npx-dbos-cloud-app-register).
+To enable time travel for your application, specify `--enable-timetravel` when you [register your application](../api-reference/cloud-cli#npx-dbos-cloud-app-register).
 :::
 
 After you've registered your application, deploy it to run it in the cloud.

--- a/docs/cloud-tutorials/application-management.md
+++ b/docs/cloud-tutorials/application-management.md
@@ -24,6 +24,10 @@ npx dbos-cloud app register -d <database-instance-name>
 Your application is automatically registered under the name in its `package.json`.
 Application names should be between 3 and 30 characters and must contain only lowercase letters and numbers, dashes (`-`), and underscores (`_`).
 
+:::tip
+Time travel is disabled by default. To enable time travel for your application, please specify `--enable-timetravel` when you [register your application](../api-reference/cloud-cli#npx-dbos-cloud-app-register).
+:::
+
 After you've registered your application, deploy it to run it in the cloud.
 Run this command in your application root directory:
 

--- a/docs/cloud-tutorials/interactive-timetravel.md
+++ b/docs/cloud-tutorials/interactive-timetravel.md
@@ -11,7 +11,7 @@ In this guide, you'll learn how to interactively time travel with DBOS Cloud: ho
 
 ### Preliminaries
 
-Before following the steps in this guide, make sure you've [deployed an application to DBOS Cloud](application-management).
+Before following the steps in this guide, make sure you've [deployed an application to DBOS Cloud](application-management) **with time travel enabled**.
 
 In order to time travel, you need to locally install our time travel proxy.
 Please follow our [time travel debugging tutorial](./timetravel-debugging) to install the proxy via VSCode or manually.

--- a/docs/cloud-tutorials/interactive-timetravel.md
+++ b/docs/cloud-tutorials/interactive-timetravel.md
@@ -11,7 +11,7 @@ In this guide, you'll learn how to interactively time travel with DBOS Cloud: ho
 
 ### Preliminaries
 
-Before following the steps in this guide, make sure you've [deployed an application to DBOS Cloud](application-management) **with time travel enabled**.
+Before following the steps in this guide, make sure you've [deployed an application to DBOS Cloud](application-management) with [time travel enabled](../api-reference/cloud-cli#npx-dbos-cloud-app-register).
 
 In order to time travel, you need to locally install our time travel proxy.
 Please follow our [time travel debugging tutorial](./timetravel-debugging) to install the proxy via VSCode or manually.

--- a/docs/cloud-tutorials/timetravel-debugging.md
+++ b/docs/cloud-tutorials/timetravel-debugging.md
@@ -18,7 +18,7 @@ For Free Tier DBOS applications, time travel debug information is only kept for 
 
 ### Preliminaries
 
-Before following the steps in this guide, make sure you've [deployed an application to DBOS Cloud](application-management).
+Before following the steps in this guide, make sure you've [deployed an application to DBOS Cloud](application-management) **with time travel enabled**.
 
 Time travel debugging uses [Visual Studio Code](https://code.visualstudio.com/) and the
 [DBOS Time Travel Debugger Extension](https://marketplace.visualstudio.com/items?itemName=dbos-inc.dbos-ttdbg).

--- a/docs/cloud-tutorials/timetravel-debugging.md
+++ b/docs/cloud-tutorials/timetravel-debugging.md
@@ -18,7 +18,7 @@ For Free Tier DBOS applications, time travel debug information is only kept for 
 
 ### Preliminaries
 
-Before following the steps in this guide, make sure you've [deployed an application to DBOS Cloud](application-management) **with time travel enabled**.
+Before following the steps in this guide, make sure you've [deployed an application to DBOS Cloud](application-management) with [time travel enabled](../api-reference/cloud-cli#npx-dbos-cloud-app-register).
 
 Time travel debugging uses [Visual Studio Code](https://code.visualstudio.com/) and the
 [DBOS Time Travel Debugger Extension](https://marketplace.visualstudio.com/items?itemName=dbos-inc.dbos-ttdbg).

--- a/docs/getting-started/quickstart-tt-debugger.md
+++ b/docs/getting-started/quickstart-tt-debugger.md
@@ -91,10 +91,15 @@ npx dbos-cloud register -u <username>
 npx dbos-cloud db provision <database-instance-name> -U <database-username>
 ```
 
+:::tip
+Time travel is disabled by default. If you already deployed an application from quickstart, please delete your application by running `npx dbos-cloud app delete`,
+and follow the instructions to re-register your application with the `--enable-timetravel` option.
+:::
+
 You can then deploy the app to DBOS Cloud by executing these commands from project's root folder:
 
 ```
-npx dbos-cloud app register -d <database-instance-name>
+npx dbos-cloud app register -d <database-instance-name> --enable-timetravel
 npx dbos-cloud app deploy
 ```
 

--- a/docs/getting-started/quickstart-tt-debugger.md
+++ b/docs/getting-started/quickstart-tt-debugger.md
@@ -92,7 +92,8 @@ npx dbos-cloud db provision <database-instance-name> -U <database-username>
 ```
 
 :::tip
-Time travel is disabled by default. If you already deployed an application from quickstart, please delete your application by running `npx dbos-cloud app delete`,
+Make sure you enable time travel when registering your application!
+If you already deployed an application from quickstart, please delete your application by running `npx dbos-cloud app delete`,
 and follow the instructions to re-register your application with the `--enable-timetravel` option.
 :::
 


### PR DESCRIPTION
Now we disable time travel by default and can be manually enabled through app registration.