### PR TITLE
document Cloud setup steps

### DIFF
--- a/docs/cloud-tutorials/application-management.md
+++ b/docs/cloud-tutorials/application-management.md
@@ -16,7 +16,7 @@ To deploy your application to DBOS Cloud, run this command in its root directory
 dbos-cloud app deploy
 ```
 
-Your application is deployed using the `name` in its [dbos-config.yaml](#configuring-application-deployment).
+Your application is deployed using the `name` in its `dbos-config.yaml`.
 Application names should be between 3 and 30 characters and must contain only lowercase letters and numbers, dashes (`-`), and underscores (`_`). Application names are unique within an [organization](account-management#organization-management).
 
 The first time you deploy an application, you are prompted to choose to which [database instance](../cloud-tutorials/database-management.md) to connect your app, or to provision one if you have none.

--- a/docs/cloud-tutorials/application-management.md
+++ b/docs/cloud-tutorials/application-management.md
@@ -26,12 +26,12 @@ Each time you deploy an application, the following steps execute:
 
 1. **Upload**: An archive of your application folder is created and uploaded to DBOS Cloud. This archive can be up to 500 MB in size.
 2. **Configuration**: Your application's dependencies are installed and the application is built.
-    - In Python, dependencies are loaded from `requirements.txt`. In TypeScript, they are loaded from `package-lock.json`, or from `package.json` if the latter is not present. You must provide one of these files to successfully deploy. The maximum size of your app after all dependencies are installed is 2 GB.
+    - In Python, dependencies are loaded from `requirements.txt`. In TypeScript, they are loaded from `package-lock.json`, or from `package.json` if the latter is not present. You must provide one of these files to successfully deploy.
+    - The maximum size of your app after all dependencies are installed is 2 GB.
     - In TypeScript, your application is built using `npm run build`.
-    - All database migrations specified in your [dbos-config.yaml](#configuring-application-deployment) are run on your cloud database.
-3. **Deployment**:
-    - Your application is deployed to a number of [Firecracker microVMs](https://firecracker-microvm.github.io/) with 1vCPU and 512MB of RAM by default. DBOS Pro subscribers can [configure](../cloud-tutorials/cloud-cli#dbos-cloud-app-update) the amount of memory allocated to each microVM.
-    - You can [configure](#configuring-application-deployment) the behavior of `dbos start` in `dbos-config.yaml`.
+    - After dependencies are installed, all database migrations specified in your `dbos-config.yaml` are run on your cloud database.
+3. **Deployment**: Your application is deployed to a number of [Firecracker microVMs](https://firecracker-microvm.github.io/) with 1vCPU and 512MB of RAM by default.
+- DBOS Pro subscribers can [configure](../cloud-tutorials/cloud-cli#dbos-cloud-app-update) the amount of memory allocated to each microVM.
 
 MicroVMs expect your application to serve requests from port 8000 (Python&mdash;the default port for FastAPI and Gunicorn) or 3000 (TypeScript&mdash;the default port for DBOS Transact and Koa).
 
@@ -55,7 +55,6 @@ This script can customize the runtime environment for your application, for exam
 
 A setup script must be specified in your `dbos-config.yaml` like so:
 
-
 ```yaml title="dbos-config.yaml"
 runtimeConfig:
     # Script DBOS Cloud runs to customize your application
@@ -63,7 +62,7 @@ runtimeConfig:
     # Requires a DBOS Pro subscription.
     setup:
         - "./build.sh"
-    # Command DBOS Cloud will execute to start your application.
+    # Command DBOS Cloud executes to start your application.
     start: <your-start-command>
 ```
 

--- a/docs/cloud-tutorials/application-management.md
+++ b/docs/cloud-tutorials/application-management.md
@@ -26,7 +26,7 @@ Each time you deploy an application, the following steps execute:
 
 1. **Upload**: An archive of your application folder is created and uploaded to DBOS Cloud. This archive can be up to 500 MB in size.
 2. **Configuration**: Your application's dependencies are installed and the application is built.
-    - In Python, dependencies are loaded from `requirements.txt`. In TypeScript, they are loaded from `package-lock.json`, or from `package.json` if the latter is not present. You must provide one of these files to successfully deploy.
+    - In Python, dependencies are loaded from `requirements.txt`. In TypeScript, they are loaded from `package-lock.json`, or from `package.json` if the former is not present. You must provide one of these files to successfully deploy.
     - The maximum size of your app after all dependencies are installed is 2 GB.
     - In TypeScript, your application is built using `npm run build`.
     - After dependencies are installed, all database migrations specified in your `dbos-config.yaml` are run on your cloud database.

--- a/docs/cloud-tutorials/application-management.md
+++ b/docs/cloud-tutorials/application-management.md
@@ -28,7 +28,6 @@ Each time you deploy an application, the following steps execute:
 2. **Configuration**: Your application's dependencies are installed and the application is built.
     - In Python, dependencies are loaded from `requirements.txt`. In TypeScript, they are loaded from `package-lock.json`, or from `package.json` if the latter is not present. You must provide one of these files to successfully deploy. The maximum size of your app after all dependencies are installed is 2 GB.
     - In TypeScript, your application is built using `npm run build`.
-    - DBOS Pro subscribers can [configure](#configuring-application-deployment) _setup steps_ to run before the application is built. These steps are meant to customize the runtime environment for your application, for example installing system packages and libraries.
     - All database migrations specified in your [dbos-config.yaml](#configuring-application-deployment) are run on your cloud database.
 3. **Deployment**:
     - Your application is deployed to a number of [Firecracker microVMs](https://firecracker-microvm.github.io/) with 1vCPU and 512MB of RAM by default. DBOS Pro subscribers can [configure](../cloud-tutorials/cloud-cli#dbos-cloud-app-update) the amount of memory allocated to each microVM.
@@ -49,24 +48,32 @@ If you edit your application, run `dbos-cloud app deploy` again to apply the lat
 * You cannot change the database of a deployed application. You must delete and re-deploy the application.
 :::
 
-#### Configuring Application Deployment
-In `dbos-config.yaml`, you can configure your application deployment with these properties:
-```yaml
-# The name of your application.
-name: <app-name>
-# Commands DBOS Cloud executes against the application database before starting the application.
-migrate:
-    - "alembic upgrade head"
+#### Customizing MicroVM Setup
+
+DBOS Pro subscribers can provide a _setup script_ that runs before their application is built.
+This script can customize the runtime environment for your application, for example installing system packages and libraries.
+
+A setup script must be specified in your `dbos-config.yaml` like so:
+
+
+```yaml title="dbos-config.yaml"
 runtimeConfig:
-    # Commands DBOS Cloud runs to configure the application runtime, before starting it.
-    # We recommend using a single script to declare commands.
+    # Script DBOS Cloud runs to customize your application
+    # runtime before building your application.
     # Requires a DBOS Pro subscription.
     setup:
-        - "apt install -y <package-name>"
-        - "cd <my_dir> && make install"
         - "./build.sh"
     # Command DBOS Cloud will execute to start your application.
-    start: "npm run start"
+    start: <your-start-command>
+```
+
+A script may install system packages or libraries or otherwise customize the microVM image. For example:
+
+```python title="build.sh"
+#!/bin/bash
+
+# Install the traceroute package for use in your application
+apt install traceroute
 ```
 
 ### Monitoring and Debugging Applications

--- a/docs/cloud-tutorials/application-management.md
+++ b/docs/cloud-tutorials/application-management.md
@@ -66,7 +66,7 @@ runtimeConfig:
     start: <your-start-command>
 ```
 
-A script may install system packages or libraries or otherwise customize the microVM image. For example:
+A setup script may install system packages or libraries or otherwise customize the microVM image. For example:
 
 ```python title="build.sh"
 #!/bin/bash

--- a/docs/cloud-tutorials/application-management.md
+++ b/docs/cloud-tutorials/application-management.md
@@ -52,14 +52,21 @@ If you edit your application, run `dbos-cloud app deploy` again to apply the lat
 #### Configuring Application Deployment
 In `dbos-config.yaml`, you can configure your application deployment with these properties:
 ```yaml
+# The name of your application.
 name: <app-name>
+# Commands DBOS Cloud executes against the application database before starting the application.
 migrate:
     - "alembic upgrade head"
 runtimeConfig:
-    setup: # Declare steps to run on the cloud before starting the application
+    # Commands DBOS Cloud runs to configure the application runtime, before starting it.
+    # We recommend using a single script to declare commands.
+    # Requires a DBOS Pro subscription.
+    setup:
         - "apt install -y <package-name>"
         - "cd <my_dir> && make install"
-    start: "npm run start" # Command to start the application.
+        - "./build.sh"
+    # Command DBOS Cloud will execute to start your application.
+    start: "npm run start"
 ```
 
 ### Monitoring and Debugging Applications

--- a/docs/cloud-tutorials/application-management.md
+++ b/docs/cloud-tutorials/application-management.md
@@ -26,7 +26,7 @@ Each time you deploy an application, the following steps execute:
 
 1. **Upload**: An archive of your application folder is created and uploaded to DBOS Cloud. This archive can be up to 500 MB in size.
 2. **Configuration**: Your application's dependencies are installed and the application is built.
-    - In Python, dependencies are loaded from `requirements.txt`. In TypeScript, they are loaded from `package-lock.json`, or from `package.json` if the former is not present. You must provide one of these files to successfully deploy.
+    - In Python, dependencies are loaded from `requirements.txt`. In TypeScript, they are loaded from `package-lock.json`, or from `package.json` if the former is not present.
     - The maximum size of your app after all dependencies are installed is 2 GB.
     - In TypeScript, your application is built using `npm run build`.
     - After dependencies are installed, all database migrations specified in your `dbos-config.yaml` are run on your cloud database.

--- a/docs/cloud-tutorials/application-management.md
+++ b/docs/cloud-tutorials/application-management.md
@@ -50,7 +50,7 @@ If you edit your application, run `dbos-cloud app deploy` again to apply the lat
 :::
 
 #### Configuring Application Deployment
-In `dbos-config.yaml`, you can configure the following properties for your application:
+In `dbos-config.yaml`, you can configure your application deployment with these properties:
 ```yaml
 name: <app-name>
 migrate:

--- a/docs/cloud-tutorials/application-management.md
+++ b/docs/cloud-tutorials/application-management.md
@@ -26,8 +26,7 @@ Each time you deploy an application, the following steps execute:
 
 1. **Upload**: An archive of your application folder is created and uploaded to DBOS Cloud. This archive can be up to 500 MB in size.
 2. **Configuration**: Your application's dependencies are installed and the application is built.
-    - In Python, dependencies are loaded from `requirements.txt`. In TypeScript, they are loaded from `package-lock.json`, or from `package.json` if the former is not present.
-    - The maximum size of your app after all dependencies are installed is 2 GB.
+    - In Python, dependencies are loaded from `requirements.txt`. In TypeScript, they are loaded from `package-lock.json`, or from `package.json` if the former is not present. The maximum size of your app after all dependencies are installed is 2 GB.
     - In TypeScript, your application is built using `npm run build`.
     - After dependencies are installed, all database migrations specified in your `dbos-config.yaml` are run on your cloud database.
 3. **Deployment**: Your application is deployed to a number of [Firecracker microVMs](https://firecracker-microvm.github.io/) with 1vCPU and 512MB of RAM by default.

--- a/docs/cloud-tutorials/application-management.md
+++ b/docs/cloud-tutorials/application-management.md
@@ -30,7 +30,7 @@ Each time you deploy an application, the following steps execute:
     - In TypeScript, your application is built using `npm run build`.
     - After dependencies are installed, all database migrations specified in your `dbos-config.yaml` are run on your cloud database.
 3. **Deployment**: Your application is deployed to a number of [Firecracker microVMs](https://firecracker-microvm.github.io/) with 1vCPU and 512MB of RAM by default.
-- DBOS Pro subscribers can [configure](../cloud-tutorials/cloud-cli#dbos-cloud-app-update) the amount of memory allocated to each microVM.
+    - DBOS Pro subscribers can [configure](../cloud-tutorials/cloud-cli#dbos-cloud-app-update) the amount of memory allocated to each microVM.
 
 MicroVMs expect your application to serve requests from port 8000 (Python&mdash;the default port for FastAPI and Gunicorn) or 3000 (TypeScript&mdash;the default port for DBOS Transact and Koa).
 

--- a/docs/python/reference/configuration.md
+++ b/docs/python/reference/configuration.md
@@ -70,6 +70,7 @@ If either does not exist, the Postgres role must have the [`CREATEDB`](https://w
 This section is used to specify DBOS runtime parameters.
 
 - **start**: The command(s) with which to start your app. Called from `dbos start`.
+- **setup**: Setup commands to run before your application is built in DBOS Cloud. Used only in DBOS Cloud. Documentation [here](../../cloud-tutorials/application-management.md#customizing-microvm-setup)
 
 **Example**:
 

--- a/docs/typescript/reference/configuration.md
+++ b/docs/typescript/reference/configuration.md
@@ -75,6 +75,7 @@ This section is used to specify DBOS runtime parameters.
 
 - **port** (optional): The port from which to serve your functions. Defaults to `3000`. Using [`npx dbos start -p <port>`](./cli#npx-dbos-start) overrides this config parameter.
 - **entrypoints** (optional): The compiled JavaScript files where DBOS looks for your application's code. At startup, the DBOS runtime automatically loads all classes exported from these files, serving their endpoints and registering their decorated functions. Defaults to `[dist/operations.js]`.
+- **setup**: Setup commands to run before your application is built in DBOS Cloud. Used only in DBOS Cloud. Documentation [here](../../cloud-tutorials/application-management.md#customizing-microvm-setup)
 
 **Example**:
 


### PR DESCRIPTION
- Document setup steps
- Add a config section to cloud application management

As we make the cloud configuration more flexible, we should make it easier for readers to read which options can be set (in the same page)