### PR TITLE
Consistent Integration Guides

### DIFF
--- a/docs/integrations/adding-dbos-to-next.md
+++ b/docs/integrations/adding-dbos-to-next.md
@@ -120,7 +120,6 @@ DBOS and `server.ts` require some TypeScript compiler settings.  These can eithe
 {
   "compilerOptions": {
     "experimentalDecorators": true,
-    "emitDecoratorMetadata": true,
     "noEmit": false,
     "outDir": "./dist",
   },
@@ -133,7 +132,6 @@ DBOS and `server.ts` require some TypeScript compiler settings.  These can eithe
 
 Noteworthy settings:
 - `experimentalDecorators`: Used by the DBOS decorator framework
-- `emitDecoratorMetadata`: Used by the DBOS decorator framework
 - `noEmit`, `outDir`, and `exclude`: Many Next.js projects do not emit the `.js` files corresponding to the `.ts` files; the bundles hold all the code.  With a custom `server.ts`, `.js` files are needed for server code for execution by the `node` runtime.
 
 ### `package.json` Scripts

--- a/docs/integrations/adding-dbos-to-next.md
+++ b/docs/integrations/adding-dbos-to-next.md
@@ -1,17 +1,18 @@
 ---
 sidebar_position: 40
-title: Adding DBOS to Next.js Apps
-description: Learn how to integrate DBOS into Next.js applications.
+title: Next.js + DBOS
 ---
 
 # Introduction
 
+This guide shows you how to add the open source [DBOS Transact](https://github.com/dbos-inc/dbos-transact-ts) library to your existing Next.js application to **durably execute** it and make it resilient to any failure.
+
 ## Why Add DBOS To a Next.js Application?
-[Next.js](https://nextjs.org/) is a solid choice for high-performance interactive web frontends.  By adding DBOS Transact, and running in a suitable hosting environment (such as [DBOS Cloud](https://www.dbos.dev/dbos-cloud)), your Next.js application can implement "heavy lifting" tasks with:
+[Next.js](https://nextjs.org/) is a solid choice for high-performance interactive web frontends.  By adding DBOS Transact, and running in a suitable hosting environment (such as [DBOS Cloud](https://www.dbos.dev/dbos-cloud)), your Next.js application can also implement "heavy lifting" backend tasks with:
 - Lightweight durable execution – DBOS [workflows](../typescript/tutorials/workflow-tutorial) run to completion exactly once.
-- Simple, powerful database integration – [Manage database data](../typescript/tutorials/transaction-tutorial) with DBOS.
+- Reliable background tasks - Use DBOS [queues](../typescript/tutorials/queue-tutorial.md) to run any task in the background and guarantee it eventually completes, no matter how long it takes.
 - Cron-style task scheduling – Automate recurring jobs with [cron-like scheduling](../typescript/tutorials/scheduled-workflows).
-- Built-in tracing and replay debugging – [Find workflows in the dashboard](../cloud-tutorials/monitoring-dashboard) and [re-run them locally](../cloud-tutorials/interactive-timetravel).
+- Built-in tracing and replay debugging – [Find workflows in the dashboard](../cloud-tutorials/monitoring-dashboard) and [re-run them locally](../typescript/tutorials/debugging.md).
 
 ## Architectural Overview
 Next.js is a framework that optimizes where and when [React](https://react.dev/) UI components render—whether on the client, server, or edge—while also handling routing, data fetching, and performance optimizations.  Part of this architecture involves the creation of minimized code bundles for handling requests.  These bundles can be loaded quickly in a “serverless” environment, leading to minimal request latency even when the server is “cold”.  This “serverless” style of deployment precludes any long-running jobs, background tasks that execute while no client requests are pending, or long-lived server objects such as WebSockets:

--- a/docs/integrations/adding-dbos-to-next.md
+++ b/docs/integrations/adding-dbos-to-next.md
@@ -3,8 +3,6 @@ sidebar_position: 40
 title: Next.js + DBOS
 ---
 
-# Introduction
-
 This guide shows you how to add the open source [DBOS Transact](https://github.com/dbos-inc/dbos-transact-ts) library to your existing Next.js application to **durably execute** it and make it resilient to any failure.
 
 ## Why Add DBOS To a Next.js Application?

--- a/docs/integrations/adding-dbos-to-next.md
+++ b/docs/integrations/adding-dbos-to-next.md
@@ -131,7 +131,7 @@ DBOS and `server.ts` require some TypeScript compiler settings.  These can eithe
 ```
 
 Noteworthy settings:
-- `experimentalDecorators`: Used by the DBOS decorator framework
+- `experimentalDecorators`: Required to use TypeScript decorators
 - `noEmit`, `outDir`, and `exclude`: Many Next.js projects do not emit the `.js` files corresponding to the `.ts` files; the bundles hold all the code.  With a custom `server.ts`, `.js` files are needed for server code for execution by the `node` runtime.
 
 ### `package.json` Scripts

--- a/docs/integrations/nestjs.md
+++ b/docs/integrations/nestjs.md
@@ -1,7 +1,6 @@
 ---
 sidebar_position: 2
-title: Nest.js
-description: Learn how to integrate DBOS into Nest.js applications.
+title: Nest.js + DBOS
 ---
 
 This guide shows you how to add the open source [DBOS Transact](https://github.com/dbos-inc/dbos-transact-ts) library to your existing [Nest.js](https://nestjs.com/) application to **durably execute** it and make it resilient to any failure.
@@ -115,8 +114,6 @@ export class AppModule {}
 ```
 
 If you need multiple instances of your DBOS class, you must give them distinct names (`dbosService` in this case). You can create a dedicated provider for each or use a single provider for multiple classes, at your convenience.
-
-Your reliable business logic is now reliable!
 
 ## Running in DBOS Cloud
 DBOS Cloud seamlessly autoscales your application to millions of users and provides built-in dashboards for observability and monitoring.

--- a/docs/python/examples/_category_.json
+++ b/docs/python/examples/_category_.json
@@ -1,5 +1,5 @@
 {
     "label": "Example Applications",
-    "position": 3
+    "position": 50
 }
   

--- a/docs/python/integrating-dbos.md
+++ b/docs/python/integrating-dbos.md
@@ -51,7 +51,7 @@ DBOS.launch()
 
 Try starting your application.
 When `DBOS.launch()` is called, it will attempt to connect to a Postgres database.
-If your project is already using Postgres, add the connection information for your database to [`dbos-config.yaml`](../reference/configuration.md).
+If your project is already using Postgres, add the connection information for your database to [`dbos-config.yaml`](./reference/configuration.md).
 Otherwise, DBOS will automatically guide you through launching a new database and connecting to it.
 
 After you've connected to Postgres, your app should run normally, but log `Initializing DBOS` and `DBOS launched` on startup.
@@ -71,13 +71,13 @@ Congratulations!  You've integrated DBOS into your application.
 <article className="col col--6">
 
 At this point, you can add any DBOS decorator or method to your application.
-For example, you can annotate one of your functions as a [workflow](./workflow-tutorial.md) and the functions it calls as [steps](./step-tutorial.md).
+For example, you can annotate one of your functions as a [workflow](./tutorials/workflow-tutorial.md) and the functions it calls as [steps](./tutorials/step-tutorial.md).
 DBOS durably executes the workflow so if it is ever interrupted, upon restart it automatically resumes from the last completed step.
 
 You can add DBOS to your application incrementally&mdash;it won't interfere with code that's already there.
 It's totally okay for your application to have one DBOS workflow alongside thousands of lines of non-DBOS code.
 
-To learn more about programming with DBOS, check out [the guide](../programming-guide.md).
+To learn more about programming with DBOS, check out [the guide](./programming-guide.md).
 
 </article>
 
@@ -152,7 +152,7 @@ pip freeze > requirements.txt
 #### 3. Define a Start Command
 <section className="row list">
 <article className="col col--6">
-Set the `start` command in the `runtimeConfig` section of your [`dbos-config.yaml`](../reference/configuration.md) to your application's launch command.
+Set the `start` command in the `runtimeConfig` section of your [`dbos-config.yaml`](./reference/configuration.md) to your application's launch command.
 
 If your application includes an HTTP server, configure it to listen on port 8000.
 

--- a/docs/python/integrating-dbos.md
+++ b/docs/python/integrating-dbos.md
@@ -1,14 +1,13 @@
 ---
-sidebar_position: 100
-title: Adding DBOS To Your App
+sidebar_position: 20
+title: Add DBOS To Your App
 pagination_next: null
 ---
 import InstallNode from '/docs/partials/_install_node.mdx';
 import LocalPostgres from '/docs/partials/_local_postgres.mdx';
 
 
-This guide shows you how to add the open source [DBOS Transact](https://github.com/dbos-inc/dbos-transact-py) library to your existing application to **durably execute** it and make it resilient to any failure.
-It also shows you how to serverlessly deploy your application to DBOS Cloud and scale it to millions of users.
+This guide shows you how to add the open-source [DBOS Transact](https://github.com/dbos-inc/dbos-transact-py) library to your existing application to **durably execute** it and make it resilient to any failure.
 
 ### Using DBOS Transact
 

--- a/docs/python/integrating-dbos.md
+++ b/docs/python/integrating-dbos.md
@@ -3,7 +3,6 @@ sidebar_position: 20
 title: Add DBOS To Your App
 ---
 import InstallNode from '/docs/partials/_install_node.mdx';
-import LocalPostgres from '/docs/partials/_local_postgres.mdx';
 
 
 This guide shows you how to add the open-source [DBOS Transact](https://github.com/dbos-inc/dbos-transact-py) library to your existing application to **durably execute** it and make it resilient to any failure.

--- a/docs/python/integrating-dbos.md
+++ b/docs/python/integrating-dbos.md
@@ -1,7 +1,6 @@
 ---
 sidebar_position: 20
 title: Add DBOS To Your App
-pagination_next: null
 ---
 import InstallNode from '/docs/partials/_install_node.mdx';
 import LocalPostgres from '/docs/partials/_local_postgres.mdx';
@@ -73,7 +72,7 @@ Congratulations!  You've integrated DBOS into your application.
 
 At this point, you can add any DBOS decorator or method to your application.
 For example, you can annotate one of your functions as a [workflow](./workflow-tutorial.md) and the functions it calls as [steps](./step-tutorial.md).
-DBOS durably executes the workflow so if it is ever interrupted, upon restart it automatically recovers to the last completed step.
+DBOS durably executes the workflow so if it is ever interrupted, upon restart it automatically resumes from the last completed step.
 
 You can add DBOS to your application incrementally&mdash;it won't interfere with code that's already there.
 It's totally okay for your application to have one DBOS workflow alongside thousands of lines of non-DBOS code.

--- a/docs/python/programming-guide.md
+++ b/docs/python/programming-guide.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 1
+sidebar_position: 10
 title: Learn DBOS Python
 pagination_next: python/tutorials/workflow-tutorial
 pagination_prev: quickstart

--- a/docs/python/reference/_category_.json
+++ b/docs/python/reference/_category_.json
@@ -1,4 +1,4 @@
 {
   "label": "API Reference",
-  "position": 2
+  "position": 40
 }

--- a/docs/python/tutorials/_category_.json
+++ b/docs/python/tutorials/_category_.json
@@ -1,4 +1,4 @@
 {
   "label": "Tutorials",
-  "position": 1
+  "position": 30
 }

--- a/docs/typescript/examples/_category_.json
+++ b/docs/typescript/examples/_category_.json
@@ -1,5 +1,5 @@
 {
     "label": "Example Applications",
-    "position": 3
+    "position": 50
 }
   

--- a/docs/typescript/integrating-dbos.md
+++ b/docs/typescript/integrating-dbos.md
@@ -1,11 +1,9 @@
 ---
-sidebar_position: 100
-title: Adding DBOS To Your App
-pagination_next: null
+sidebar_position: 20
+title: Add DBOS To Your App
 ---
 
-This guide shows you how to add the open source [DBOS Transact](https://github.com/dbos-inc/dbos-transact-ts) library to your existing application to **durably execute** it and make it resilient to any failure.
-It also shows you how to serverlessly deploy your application to DBOS Cloud and scale it to millions of users.
+This guide shows you how to add the open-source [DBOS Transact](https://github.com/dbos-inc/dbos-transact-ts) library to your existing application to **durably execute** it and make it resilient to any failure.
 
 ### Using DBOS Transact
 
@@ -28,19 +26,18 @@ telemetry:
     logLevel: 'info'
 ```
 
-Also, set the following settings in your `tsconfig.json` file, which enable TypeScript decorators:
+Also, enable TypeScript decorators in your `tsconfig.json` file:
 
 ```json title="tsconfig.json"
   "compilerOptions": {
     "experimentalDecorators": true,
-    "emitDecoratorMetadata": true,
   }
 ```
 
 
 #### 2. Initialize DBOS in Your App
 
-In your app's main entrypoint, add the following lines of code.
+In your app's main entrypoint, add the following code.
 This initializes DBOS when your app starts.
 
 ```javascript
@@ -68,7 +65,7 @@ Congratulations!  You've integrated DBOS into your application.
 
 At this point, you can add any DBOS decorator or method to your application.
 For example, you can annotate one of your functions as a [workflow](./workflow-tutorial.md) and the functions it calls as [steps](./step-tutorial.md).
-DBOS durably executes the workflow so if it is ever interrupted, upon restart it automatically recovers to the last completed step.
+DBOS durably executes the workflow so if it is ever interrupted, upon restart it automatically resumes from the last completed step.
 
 ```typescript
 export class Example {

--- a/docs/typescript/integrating-dbos.md
+++ b/docs/typescript/integrating-dbos.md
@@ -5,6 +5,12 @@ title: Add DBOS To Your App
 
 This guide shows you how to add the open-source [DBOS Transact](https://github.com/dbos-inc/dbos-transact-ts) library to your existing application to **durably execute** it and make it resilient to any failure.
 
+:::info
+Also check out the integration guides for popular TypeScript frameworks:
+- [Next.js + DBOS](../integrations/adding-dbos-to-next.md)
+- [Nest.js + DBOS](../integrations/nestjs.md)
+:::
+
 ### Using DBOS Transact
 
 #### 1. Install DBOS

--- a/docs/typescript/integrating-dbos.md
+++ b/docs/typescript/integrating-dbos.md
@@ -60,8 +60,8 @@ Try starting your application:
 npm start # Or use your own start command
 ```
 
-When [`await DBOS.launch()`](../reference/transactapi/dbos-class#launching-dbos) is called, it will attempt to connect to a Postgres database.
-If your project is already using Postgres, add the connection information for your database to [`dbos-config.yaml`](../reference/configuration#database).
+When [`await DBOS.launch()`](./reference/transactapi/dbos-class#launching-dbos) is called, it will attempt to connect to a Postgres database.
+If your project is already using Postgres, add the connection information for your database to [`dbos-config.yaml`](./reference/configuration#database).
 Otherwise, DBOS will automatically guide you through launching a new database and connecting to it.
 
 After you've connected to Postgres, your app should run normally, but log `DBOS launched` on startup.
@@ -70,7 +70,7 @@ Congratulations!  You've integrated DBOS into your application.
 #### 4. Start Building With DBOS
 
 At this point, you can add any DBOS decorator or method to your application.
-For example, you can annotate one of your functions as a [workflow](./workflow-tutorial.md) and the functions it calls as [steps](./step-tutorial.md).
+For example, you can annotate one of your functions as a [workflow](./tutorials/workflow-tutorial.md) and the functions it calls as [steps](./tutorials/step-tutorial.md).
 DBOS durably executes the workflow so if it is ever interrupted, upon restart it automatically resumes from the last completed step.
 
 ```typescript
@@ -94,7 +94,7 @@ To ensure that DBOS registers all decorated functions, **declare all DBOS-decora
 You can add DBOS to your application incrementally&mdash;it won't interfere with code that's already there.
 It's totally okay for your application to have one DBOS workflow alongside thousands of lines of non-DBOS code.
 
-To learn more about programming with DBOS, check out [the programming guide](../programming-guide.md).
+To learn more about programming with DBOS, check out [the programming guide](./programming-guide.md).
 
 ### Deploying to DBOS Cloud
 
@@ -113,7 +113,7 @@ npm i -g @dbos-inc/dbos-cloud@latest
 
 #### 2. Define a Start Command
 
-Set the `start` command in the `runtimeConfig` section of your [`dbos-config.yaml`](../reference/configuration.md) to your application's launch command.
+Set the `start` command in the `runtimeConfig` section of your [`dbos-config.yaml`](./reference/configuration.md) to your application's launch command.
 
 ```yaml title="dbos-config.yaml"
 runtimeConfig:

--- a/docs/typescript/programming-guide.md
+++ b/docs/typescript/programming-guide.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 1
+sidebar_position: 10
 title: Learn DBOS TypeScript
 pagination_next: typescript/tutorials/workflow-tutorial
 pagination_prev: quickstart

--- a/docs/typescript/reference/_category_.json
+++ b/docs/typescript/reference/_category_.json
@@ -1,4 +1,4 @@
 {
   "label": "Reference",
-  "position": 2
+  "position": 40
 }

--- a/docs/typescript/tutorials/_category_.json
+++ b/docs/typescript/tutorials/_category_.json
@@ -1,4 +1,4 @@
 {
   "label": "Tutorials",
-  "position": 1
+  "position": 30
 }

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -190,6 +190,14 @@ const config = {
             from: '/python/examples/reliable-ai-agent',
             to: '/python/examples/customer-service',
           },
+          {
+            from: '/python/tutorials/integrating-dbos',
+            to: '/python/integrating-dbos',
+          },
+          {
+            from: '/typescript/tutorials/integrating-dbos',
+            to: '/typescript/integrating-dbos',
+          },
         ],
       },
     ],

--- a/package-lock.json
+++ b/package-lock.json
@@ -14115,9 +14115,9 @@
       }
     },
     "node_modules/prismjs": {
-      "version": "1.29.0",
-      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.29.0.tgz",
-      "integrity": "sha512-Kx/1w86q/epKcmte75LNrEoT+lX8pBpavuAbvJWRXar7Hz8jrtF+e3vY751p0R8H9HdArwaCTNDDzHg/ScJK1Q==",
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.30.0.tgz",
+      "integrity": "sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw==",
       "license": "MIT",
       "engines": {
         "node": ">=6"


### PR DESCRIPTION
- Make the "Add DBOS To Your App" guides more visible
- Link from there to the new framework integration guides
- Make all the integration guides more consistent
- Remove the `emitDecoratorMetadata` requirement (https://github.com/dbos-inc/dbos-transact-ts/pull/780)