### PR TITLE
Simplify object instances doc

### DIFF
--- a/docs/integrations/adding-dbos-to-next.md
+++ b/docs/integrations/adding-dbos-to-next.md
@@ -224,7 +224,7 @@ Items may be placed in `globalThis` directly.  This should generally be done bef
 globalThis.webSocketClients = gss;
 
 // Share a DBOS configured object globally
-globalThis.reportSes = DBOS.configureInstance(DBOS_SES, 'reportSES', {awscfgname: 'aws_config'});
+globalThis.reportSes = new DBOS_SES('reportSES', {awscfgname: 'aws_config'});
 
 // Share an entire class globally
 import { DBOSBored } from "./dbos_bored";

--- a/docs/integrations/nestjs.md
+++ b/docs/integrations/nestjs.md
@@ -100,7 +100,7 @@ import { DBOS } from '@dbos-inc/dbos-sdk';
 export const dbosProvider: Provider = {
   provide: AppService,
   useFactory: (prisma: PrismaService) => {
-    return DBOS.configureInstance(AppService, "dbosService", prisma);
+    return new AppService("dbosService", prisma);
   },
   inject: [PrismaService],
 };

--- a/docs/typescript/examples/kafka-alert-queue.md
+++ b/docs/typescript/examples/kafka-alert-queue.md
@@ -139,7 +139,7 @@ This workflow is guaranteed to handle every Kafka message exactly once, even if 
 To send messages, we create a KafkaProducerCommunicator object like so:
 ```typescript
 //A configured instance used to produce messages (operations.ts)
-const producerConfig: KafkaProduceStep =  DBOS.configureInstance(KafkaProduceStep, 
+const producerConfig: KafkaProduceStep = new KafkaProduceStep( 
   'wfKafka', kafkaConfig, respondTopic, {
     createPartitioner: Partitioners.DefaultPartitioner
   });

--- a/docs/typescript/examples/task-scheduler.md
+++ b/docs/typescript/examples/task-scheduler.md
@@ -214,7 +214,7 @@ The optional sending of task results emails is done using Amazon SES, and the [@
 All that is necessary, as shown in `src/dbos/operations.ts`, is to configure the email instance (using environment variables):
 ```typescript
 if (!globalThis.reportSes && (process.env['REPORT_EMAIL_TO_ADDRESS'] && process.env['REPORT_EMAIL_FROM_ADDRESS'])) {
-  globalThis.reportSes = DBOS.configureInstance(DBOS_SES, 'reportSES', {awscfgname: 'aws_config'});
+  globalThis.reportSes = new DBOS_SES('reportSES', {awscfgname: 'aws_config'});
 }
 ```
 

--- a/docs/typescript/reference/libraries.md
+++ b/docs/typescript/reference/libraries.md
@@ -110,9 +110,9 @@ application:
 The application code will then have to specify which configuration to use when initializing the step:
 ```typescript
     // Initialize once per config used...
-    const sesDef = configureInstance(DBOS_SES, 'default'});
-    const userSES = configureInstance(DBOS_SES, 'userSES', {awscfgname: 'aws_config_ses_user'});
-    const adminSES = configureInstance(DBOS_SES, 'adminSES', {awscfgname: 'aws_config_ses_admin'});
+    const sesDef = new DBOS_SES('default');
+    const userSES = new DBOS_SES('userSES', {awscfgname: 'aws_config_ses_user'});
+    const adminSES = new DBOS_SES('adminSES', {awscfgname: 'aws_config_ses_admin'});
     // Use configured object ...
     const msgid = await userSES.sendTemplatedEmail(
         mailMsg,

--- a/docs/typescript/tutorials/development/using-libraries.md
+++ b/docs/typescript/tutorials/development/using-libraries.md
@@ -31,13 +31,8 @@ While libraries such as `@dbos-inc/dbos-bcrypt` or `@dbos-inc/dbos-datetime` hav
 import { DBOS } from "@dbos-inc/dbos-sdk";
 import { DBOS_SES } from "@dbos-inc/dbos-email-ses";
 
-const sesMailer = DBOS.configureInstance(DBOS_SES, 'marketing', {awscfgname: 'marketing_email_aws_config'});
+const sesMailer = new DBOS_SES('marketing', {awscfgname: 'marketing_email_aws_config'});
 ```
-
-Note that the `configureInstance` call above serves multiple purposes:
-* Creates an instance of `DBOS_SES`
-* Provides the instance with enough information to find essential configuration information (AWS region, access key, and secret) from the configuration file
-* Registers the instance under the name 'marketing'
 
 Methods can then be called on the object instance:
 ```typescript

--- a/docs/typescript/tutorials/instantiated-objects.md
+++ b/docs/typescript/tutorials/instantiated-objects.md
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 85
-title: Using Instantiated Objects
+title: Using Typescript Objects
 description: Learn how to make workflows, transactions, and steps reusable and configurable by instantiating objects
 ---
 
@@ -51,10 +51,9 @@ All configured classes must:
 * Extend from the `ConfiguredInstance` base class
 * Provide a constructor, which can take any arguments, but must provide a name to the base `ConfiguredInstance` constructor
 * Have an `initialize(ctx: InitContext)` that will be called after all objects have been created, but before request handling commences
-* Have `@DBOS.transaction`, `@DBOS.step`, and/or `@DBOS.workflow` methods to be called on the instances
 
 ### `initialize()` Method
 The `initialize(ctx: InitContext)` method will be called during application initialization, after the code modules have been loaded, but before request and workflow processing commences.  The `InitContext` argument provides configuration file, logging, and database access services, so any validation of connection information (complete with diagnostic logging and reporting of any problems) should be performed in `initialize()`.
 
 ## Notes
-As `@DBOS.scheduled`, `@KafkaConsume`, `@DBOS.getApi`, `@DBOS.putApi`, and similar handler registration decorators cannot be applied to instance methods.
+Event and handler registration decorators such as `@DBOS.scheduled`, `@KafkaConsume`, `@DBOS.getApi`, and `@DBOS.putApi` cannot be applied to instance methods.

--- a/docs/typescript/tutorials/instantiated-objects.md
+++ b/docs/typescript/tutorials/instantiated-objects.md
@@ -4,96 +4,57 @@ title: Using Instantiated Objects
 description: Learn how to make workflows, transactions, and steps reusable and configurable by instantiating objects
 ---
 
-In this guide, you'll learn how to make your DBOS functions configurable using class objects.
-Each object can contain configuration information, available to instance methods that are registered DBOS workflow, step, or transaction functions.
+You can add DBOS workflow, step, and transaction decorators to your TypeScript class instance methods.
+To add DBOS decorators to your instance methods, their class must inherit from `ConfiguredInstance`, which will take an instance name and register the instance.
 
-## Concepts
-Basic DBOS transactions, steps, and workflows are just functions - they accept input parameters, apply those parameters to the database, or use them to place calls to external services.
-
-However, it is sometimes desirable to have configuration information available to DBOS functions.
-For example, an email-sending function may send email with one set of addresses and credentials for promotional materials to prospects, or another set of credentials for replies to support inquiries from existing customers.
-
-### Instances
-Configured class instances are the DBOS Transact mechanism for creating multiple configurations for the same code.  Rather than having `static` class member functions, configured instances have non-static member functions that can access configuration information through `this`.
-
-### Names
-While configured instances are basically regular TypeScript objects, they must have names.  Names are simply strings identifying the configuration.  These names are used by DBOS Transact internally to find the correct object instance across system restarts, but are also potentially useful for monitoring, tracing, and debugging.
-
-## Using Configured Class Instances
-Configured class instances should be created and named when the application starts, before any workflows can run.  This ensures that they will all be initialized before any processing begins.
-
-### Creating
-To create and register a class instance, the `DBOS.configureInstance` function is used:
+For example:
 ```typescript
-import { DBOS } from "@dbos-inc/dbos-sdk";
-const myObj = DBOS.configureInstance(MyClass, 'myname', args);
-```
-
-The arguments to `configureInstance` are:
-* The class to be instantiated and configured
-* The name for the configured instance (which must be unique within the set of instances of the same class)
-* Any additional arguments to pass to the class constructor
-
-```typescript
-DBOS.configureInstance(cls: Constructor, name: string, ...args: unknown[]) : R
-```
-
-Note that while this will create and register the object instance, initialization via the object's `initialize()` method will not occur until later, after database connections have been established.
-
-### Invoking
-Methods of configured instances can be invoked directly:
-
-```typescript
-MyClass.myStaticFunction(args); // Use on a static function
-myObj.myMemberFunction(args); // Use on a configured object instance
-```
-
-## Writing New Configured Classes
-
-### Declaring
-All configured classes must:
-* Extend from the `ConfiguredInstance` base class
-* Provide a constructor, which can take any arguments, but must provide a name to the base `ConfiguredInstance` constructor
-* Have an `initialize(ctx: InitContext)` that will be called after all objects have been created, but before request handling commences
-* Have `@DBOS.transaction`, `@DBOS.step`, and/or `@DBOS.workflow` methods to be called on the instances
-
-```typescript
-class MyConfiguredClass extends ConfiguredInstance {
+class MyClass extends ConfiguredInstance {
   cfg: MyConfig;
   constructor(name: string, config: MyConfig) {
     super(name);
     this.cfg = cfg;
   }
 
-  initialize(_ctx: InitContext) : Promise<void> {
-    // Validate this.cfg
-    return Promise.resolve();
+  async initialize(_ctx: InitContext) : Promise<void> {
+    // ... Validate this.cfg
   }
 
   @DBOS.transaction()
-  testTransaction() {
-    // Operations that use this.cfg
-    return Promise.resolve();
+  async testTransaction() {
+    // ... Operations that use this.cfg
   }
 
   @DBOS.step()
-  testStep() {
-    // Operations that use this.cfg
-    return Promise.resolve();
+  async testStep() {
+    // ... Operations that use this.cfg
   }
 
   @DBOS.workflow()
   async testWorkflow(p: string): Promise<void> {
-    // Operations that use this.cfg
-    return Promise.resolve();
+    // ... Operations that use this.cfg
   }
 }
+
+const myClassInstance = new MyClass('instanceA');
 ```
+
+When you create a new instance of a DBOS-decorated class, the constructor for the base `ConfiguredInstance` must be called with a `name`. This `name` should be unique among instances of the same class.   Additionally, all `ConfiguredInstance` classes must be instantiated before DBOS.launch() is called.
+
+The reason for these requirements is to enable workflow recovery.  When you create a new instance of, DBOS stores it in a global registry indexed by `name`.  When DBOS needs to recover a workflow belonging to that class, it looks up the `name` so it can run the workflow using the right class instance.  While names are used by DBOS Transact internally to find the correct object instance across system restarts, they are also potentially useful for monitoring, tracing, and debugging.
+
+## Using Configured Class Instances
+Configured class instances should be created and named when the application starts, before any workflows run.  This ensures that they will all be initialized before any processing begins.
+
+### Writing New Configured Classes
+All configured classes must:
+* Extend from the `ConfiguredInstance` base class
+* Provide a constructor, which can take any arguments, but must provide a name to the base `ConfiguredInstance` constructor
+* Have an `initialize(ctx: InitContext)` that will be called after all objects have been created, but before request handling commences
+* Have `@DBOS.transaction`, `@DBOS.step`, and/or `@DBOS.workflow` methods to be called on the instances
 
 ### `initialize()` Method
 The `initialize(ctx: InitContext)` method will be called during application initialization, after the code modules have been loaded, but before request and workflow processing commences.  The `InitContext` argument provides configuration file, logging, and database access services, so any validation of connection information (complete with diagnostic logging and reporting of any problems) should be performed in `initialize()`.
 
 ## Notes
-As `@DBOS.getApi`, `@DBOS.putApi`, and similar handler registration decorators specify the URL directly, it does not make sense to use these on configured class instances, as there is no way to tell which instance is to handle the request.
-
-The name of a workflow, and the name of the configuration in use, is kept in the DBOS system database so that interrupted workflows can be resumed.  It is therefore important to keep names consistent across application deployments, unless there is no chance that a pending workflow will need to be recovered.
+As `@DBOS.scheduled`, `@KafkaConsume`, `@DBOS.getApi`, `@DBOS.putApi`, and similar handler registration decorators cannot be applied to instance methods.


### PR DESCRIPTION
Simplifies the treatment of class instances (to be more like Python).

This removes configureInstance from the doc, as would be suitable after https://github.com/dbos-inc/dbos-transact-ts/pull/790.  There should perhaps be a waiting period ... in case someone looks at the new doc but is using an older copy of the library.
