### PR TITLE
update name in DBOS.setConfig to match the name in the dbos-node-starter template

### DIFF
--- a/docs/typescript/programming-guide.md
+++ b/docs/typescript/programming-guide.md
@@ -45,7 +45,7 @@ export class Example {
 
 async function main() {
   DBOS.setConfig({
-    "name": "dbos-starter",
+    "name": "dbos-node-starter",
     "databaseUrl": process.env.DBOS_DATABASE_URL
   });
   await DBOS.launch();


### PR DESCRIPTION
Following the programming guide, I get this error:

```
DBOSInitializationError: Provided app name 'dbos-starter' does not match the app name 'dbos-node-starter' in dbos-config.yaml
```