### PR TITLE
[docs] Fix TS examples using str instead of string

### DIFF
--- a/docs/typescript/prompting.md
+++ b/docs/typescript/prompting.md
@@ -272,7 +272,7 @@ If a workflow is called multiple times with the same ID, it executes ONLY ONCE.
 ```javascript
 class Example {
   @DBOS.workflow()
-  static async exampleWorkflow(var1: str, var2: str) {
+  static async exampleWorkflow(var1: string, var2: string) {
       return var1 + var2;
   }
 }
@@ -297,7 +297,7 @@ Here's an example:
 ```javascript
 class Example {
     @DBOS.workflow()
-    static async exampleWorkflow(var1: str, var2: str) {
+    static async exampleWorkflow(var1: string, var2: string) {
         return var1 + var2;
     }
 }

--- a/docs/typescript/tutorials/workflow-tutorial.md
+++ b/docs/typescript/tutorials/workflow-tutorial.md
@@ -104,7 +104,7 @@ For example:
 ```javascript
 class Example {
   @DBOS.workflow()
-  static async exampleWorkflow(var1: str, var2: str) {
+  static async exampleWorkflow(var1: string, var2: string) {
       return var1 + var2;
   }
 }
@@ -128,7 +128,7 @@ Here's an example:
 ```javascript
 class Example {
     @DBOS.workflow()
-    static async exampleWorkflow(var1: str, var2: str) {
+    static async exampleWorkflow(var1: string, var2: string) {
         return var1 + var2;
     }
 }


### PR DESCRIPTION
### Description of the fix/feature
Some Typescript code examples used `str` instead of `string` for string arguments. Also fixes this in the Typescript AI prompt.

### Brief description of implementation
n/a