### PR TITLE
Py cli updates

### DIFF
--- a/docs/python/reference/_category_.json
+++ b/docs/python/reference/_category_.json
@@ -1,4 +1,4 @@
 {
-  "label": "API Reference",
+  "label": "Reference",
   "position": 40
 }

--- a/docs/python/reference/cli.md
+++ b/docs/python/reference/cli.md
@@ -3,7 +3,121 @@ sidebar_position: 15
 title: DBOS CLI
 ---
 
-## Commands
+## Workflow Management Commands
+
+### dbos workflow list
+
+**Description:**
+List workflows run by your application in JSON format ordered by recency (most recently started workflows last).
+
+**Arguments:**
+* `-D, --db-url TEXT`: Your DBOS application database URL
+* `-l, --limit INTEGER`: Limit the results returned  [default: 10]
+* `-u, --user TEXT`: Retrieve workflows run by this user
+* `-s, --start-time TEXT`: Retrieve workflows starting after this timestamp (ISO 8601 format)
+* `-e, --end-time TEXT`: Retrieve workflows starting before this timestamp (ISO 8601 format)
+* `-S, --status TEXT`: Retrieve workflows with this status (PENDING, SUCCESS, ERROR, RETRIES_EXCEEDED, ENQUEUED, or CANCELLED)
+* `-v, --application-version TEXT`: Retrieve workflows with this application version
+* `-n, --name TEXT`: Retrieve workflows with this name
+* `-d, --sort-desc`: Sort the results in descending order (older first)
+* `-o, --offset INTEGER`: Offset for pagination
+
+**Output:**
+A JSON-formatted list of [workflow statuses](./contexts#workflow-status).
+
+### dbos workflow get
+
+**Description:**
+Retrieve information on a workflow run by your application.
+
+**Arguments:**
+- `<workflow-id>`: The ID of the workflow to retrieve
+- `-D, --db-url TEXT`: Your DBOS application database URL
+
+**Output:**
+A JSON-formatted [workflow status](./contexts#workflow-status).
+
+### dbos workflow steps
+
+**Arguments:**
+- `<workflow-id>`: The ID of the workflow to retrieve
+- `-D, --db-url TEXT`: Your DBOS application database URL
+
+**Output:**
+A JSON-formatted list of [workflow steps](./contexts#list_workflow_steps).
+
+### dbos workflow cancel
+
+**Description:**
+ Cancel a workflow so it is no longer automatically retried or restarted. Active executions are not halted.
+
+**Arguments:**
+- `<workflow-id>`: The ID of the workflow to cancel
+- `-D, --db-url TEXT`: Your DBOS application database URL
+
+### dbos workflow resume
+
+**Description:**
+Resume a workflow from its last completed step.
+You can use this to resume workflows that are cancelled or that have exceeded their maximum recovery attempts.
+You can also use this to start an `ENQUEUED` workflow, bypassing its queue.
+
+**Arguments:**
+- `<workflow-id>`: The ID of the workflow to resume.
+- `-D, --db-url TEXT`: Your DBOS application database URL
+
+:::info
+Resuming a workflow on a new version of your application will flag the workflow with the new version.
+:::
+
+### dbos workflow restart
+
+**Description:**
+Start a new execution of a workflow with the same inputs.
+This new workflow has a new workflow ID and is tagged with the current application version.
+
+**Arguments:**
+- `<workflow-id>`: The ID of the workflow to restart.
+- `-D, --db-url TEXT`: Your DBOS application database URL
+
+**Output:**
+A JSON-formatted [workflow status](./contexts#workflow-status).
+
+### dbos workflow fork
+
+**Description:**
+Fork a new execution of a workflow, starting at a given step.
+This new workflow has a new workflow ID and is tagged with the current application version.
+Forking from step N copies the results of all previous steps to the new workflow, which then starts running from step N.
+
+**Arguments:**
+* `<workflow-id>`: The ID of the workflow to restart.
+* `-s, --step INTEGER`: Restart from this step [default: 1]
+* `-D, --db-url TEXT`: Your DBOS application database URL
+
+**Output:**
+A JSON-formatted [workflow status](./contexts#workflow-status).
+
+### dbos workflow queue list
+
+**Description:**
+Lists all currently enqueued tasks in JSON format ordered by recency (most recently enqueued functions last).
+
+**Arguments:**
+* `-D, --db-url TEXT`: Your DBOS application database URL
+* `-l, --limit INTEGER`: Limit the results returned
+* `-s, --start-time TEXT`: Retrieve functions starting after this timestamp (ISO 8601 format)
+* `-e, --end-time TEXT`: Retrieve functions starting before this timestamp (ISO 8601 format)
+* `-S, --status TEXT`: Retrieve functions with this status (PENDING, SUCCESS, ERROR, RETRIES_EXCEEDED, ENQUEUED, or CANCELLED)
+* `-q, --queue-name TEXT`: Retrieve functions on this queue
+* `-n, --name TEXT`: Retrieve functions on this queue
+* `-d, --sort-desc`: Sort the results in descending order (older first)
+* `-o, --offset INTEGER`: Offset for pagination
+
+**Output:**
+A JSON-formatted list of [workflow statuses](./contexts#workflow-status).
+
+## Application Management Commands
 
 ### dbos start
 
@@ -37,7 +151,7 @@ Initialize the local directory with a DBOS template application.
 
 **Arguments:**
 - `<application-name>`: The name of your application. If not specified, will be prompted for.
-- `--template, -t <str>`: Specify a template to use. Currently, we have a single "hello" template, which is used by default.
+- `-t, --template TEXT`: Specify a template to use. ("dbos-toolbox", "dbos-app-starter", "dbos-cron-starter", "dbos-db-starter")
 - `--config, -c`: If this flag is set, only the `dbos-config.yaml` file is added from the template. Useful to add DBOS to an existing project.
 
 ### dbos reset
@@ -46,128 +160,13 @@ Reset your DBOS [system database](../../explanations/system-tables.md), deleting
 No application data is affected by this.
 
 **Arguments:**
-- `--yes, -y`: Skip confirmation prompt.
+* `--yes, -y`: Skip confirmation prompt.
+* `-s, --sys-db-name TEXT`: Specify the name of the system database to reset
+* `-D, --db-url TEXT`: Your DBOS application database URL
 
 ### dbos debug
 
-Execute a DBOS application in debug mode to replay a specified workflow. 
+Execute a DBOS application in debug mode to replay a specified workflow.
 
 **Arguments:**
 - `<workflow-id>`: The ID of the workflow to debug.
-
-## Workflow Management Commands
-
-### dbos workflow list
-
-**Description:**
-List workflows run by your application in JSON format ordered by recency (most recently started workflows last).
-
-**Arguments:**
-- `-n, --name <string>`                 Retrieve functions with this name
-- `-l, --limit <number>`                Limit the results returned (default: "10") 
-- `-u, --user <string>`                 Retrieve workflows run by this user
-- `-s, --start-time <string>`           Retrieve workflows starting after this timestamp (ISO 8601 format)
-- `-e, --end-time <string>`             Retrieve workflows starting before this timestamp (ISO 8601 format)
-- `-S, --status <string>`               Retrieve workflows with this status (`PENDING`, `SUCCESS`, `ERROR`, `RETRIES_EXCEEDED`, `ENQUEUED`, or `CANCELLED`)
-- `-v, --application-version <string>`  Retrieve workflows with this application version
-- `--request`                           Retrieve workflow request information
-
-**Output:**
-For each retrieved workflow, emit a JSON whose fields are:
-- `workflowUUID`: The ID of the workflow
-- `status`: The status of the workflow
-- `workflowName`: The name of the workflow function
-- `workflowClassName`: The name of the class in which the workflow function is implemented
-- `workflowConfigName`: If the workflow is in a [configured class](../reference/decorators.md#dbosconfiguredinstance), the name of the configuration
-- `authenticatedUser`: The user who ran the workflow, if specified
-- `assumedRole`: The role with which the workflow ran, if specified
-- `authenticatedRoles`: All roles which the authenticated user could assume
-- `queueName`: The queue of the workflow, if enqueued.
-- `input`: The input arguments to the workflow, in array format
-- `output`: If the workflow completed successfuly, its output
-- `error`: If the workflow threw an error, the serialized error object
-- `request`: If the workflow was invoked via HTTP and this field was specified, the serialized request object
-
-### dbos workflow get
-
-**Description:**
-Retrieve information on a workflow run by your application.
-
-**Arguments:**
-- `<workflow-id>`: The ID of the workflow to retrieve.
-- `--request`: Display workflow request information.
-
-**Output:**
-A JSON whose fields are:
-- `workflowUUID`: The ID of the workflow
-- `status`: The status of the workflow
-- `workflowName`: The name of the workflow function
-- `workflowClassName`: The name of the class in which the workflow function is implemented
-- `workflowConfigName`: If the workflow is in a [configured class](../reference/decorators.md#dbosconfiguredinstance), the name of the configuration
-- `authenticatedUser`: The user who ran the workflow, if specified
-- `assumedRole`: The role with which the workflow ran, if specified
-- `authenticatedRoles`: All roles which the authenticated user could assume
-- `queueName`: The queue of the workflow, if enqueued.
-- `input`: The input arguments to the workflow, in array format
-- `output`: If the workflow completed successfuly, its output
-- `error`: If the workflow threw an error, the serialized error object
-- `request`: If the workflow was invoked via HTTP and this field was specified, the serialized request object
-
-### dbos workflow cancel
-
-**Description:**
- Cancel a workflow so it is no longer automatically retried or restarted. Active executions are not halted.
-
-**Arguments:**
-- `<workflow-id>`: The ID of the workflow to cancel.
-
-### dbos workflow resume
-
-**Description:**
-Resume a workflow from its last completed step.
-You can use this to resume workflows that are cancelled or that have exceeded their maximum recovery attempts.
-You can also use this to start an `ENQUEUED` workflow, bypassing its queue.
-
-**Arguments:**
-- `<workflow-id>`: The ID of the workflow to resume.
-- `-d, --appDir <application-directory>`: The path to your application root directory.
-
-### dbos workflow restart
-
-**Description:**
-Start a new execution of a workflow with the same inputs.
-This new workflow has a new workflow ID.
-
-**Arguments:**
-- `<workflow-id>`: The ID of the workflow to restart.
-
-### dbos workflow queue list
-
-**Description:**
-Lists all currently enqueued functions in JSON format ordered by recency (most recently enqueued functions last).
-
-**Arguments:**
-- `-n, --name <string>`        Retrieve functions with this name
-- `-s, --start-time <string>`  Retrieve functions starting after this timestamp (ISO 8601 format)
-- `-e, --end-time <string>`    Retrieve functions starting before this timestamp (ISO 8601 format)
-- `-S, --status <string>`      Retrieve functions with this status (PENDING, SUCCESS, ERROR, RETRIES_EXCEEDED, ENQUEUED, or CANCELLED)
-- `-l, --limit <number>`       Limit the results returned
-- `-q, --queue <string>`       Retrieve functions run on this queue
-- `--request`                  Retrieve workflow request information
-- `-d, --appDir <string>`      Specify the application root directory
-
-**Output:**
-For each retrieved function, emit a JSON whose fields are:
-- `workflowUUID`: The ID of the workflow
-- `status`: The status of the workflow
-- `workflowName`: The name of the workflow function
-- `workflowClassName`: The name of the class in which the workflow function is implemented
-- `workflowConfigName`: If the workflow is in a [configured class](../reference/decorators.md#dbosconfiguredinstance), the name of the configuration
-- `authenticatedUser`: The user who ran the workflow, if specified
-- `assumedRole`: The role with which the workflow ran, if specified
-- `authenticatedRoles`: All roles which the authenticated user could assume
-- `queueName`: The queue of the workflow, if enqueued.
-- `input`: The input arguments to the workflow, in array format
-- `output`: If the workflow completed successfuly, its output
-- `error`: If the workflow threw an error, the serialized error object
-- `request`: If the workflow was invoked via HTTP and this field was specified, the serialized request object

--- a/docs/python/reference/contexts.md
+++ b/docs/python/reference/contexts.md
@@ -373,6 +373,8 @@ class WorkflowStatus:
     status: str
     # The name of the workflow function
     name: str
+    # The number of times the workflow was scheduled to run
+    recovery_attempts: int
     # The name of the workflow's class, if any
     class_name: Optional[str]
     # The name with which the workflow's class instance was configured, if any
@@ -395,10 +397,12 @@ class WorkflowStatus:
     updated_at: Optional[int]
     # If this workflow was enqueued, on which queue
     queue_name: Optional[str]
-    # The executor to most recently executed this workflow
+    # The executor to most recently executed this workflow (DBOS__VMID if set else "local")
     executor_id: Optional[str]
     # The application version on which this workflow was started
     app_version: Optional[str]
+    # The ID of the application (DBOS__APPID if set)
+    app_id: Optional[str]
 ```
 
 ## Context Variables


### PR DESCRIPTION
- Move workflow management commands on top of the page
- Update each command
- Add missing for command
- Put some emphasis on potential new version flagging of a resumed workflow
- For the outputs, reference the `WorkflowStatus` and `StepInfo` structures rather than re-typing it all
- "API Reference" becomes "Reference"