### PR TITLE
Add llms.txt

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -1,6 +1,26 @@
 // @ts-check
 // Note: type annotations allow type checking and IDEs autocompletion
 import {themes as prismThemes} from 'prism-react-renderer';
+import path from 'path';
+import fse from 'fs-extra';
+import fs from 'fs';
+
+function CopyMarkdownPlugin(context, options) {
+  return {
+    name: 'copy-markdown-plugin',
+    async postBuild({ outDir }) {
+      const docsSrc = path.join(__dirname, 'docs');
+      const docsDest = outDir; // Strip the /docs part
+
+      // Recursively copy .md files from /docs to /build/docs
+      fse.copySync(docsSrc, docsDest, {
+        filter: (src) => src.endsWith('.md') || fs.lstatSync(src).isDirectory(),
+      });
+
+      console.log('Markdown files copied to build output.');
+    },
+  };
+}
 
 /** @type {import('@docusaurus/types').Config} */
 const config = {
@@ -33,6 +53,7 @@ const config = {
   },
 
   plugins: [
+    CopyMarkdownPlugin,
     'docusaurus-plugin-matomo',
     [
       '@docusaurus/plugin-client-redirects',


### PR DESCRIPTION
This PR adds two plugins to support llms.txt according to the spec https://llmstxt.org/:
- Copy the raw `.md` file of each page to the build directory. This way, all pages will have their corresponding raw Markdown pages (url with `.md` appended). This will make it easier for LLMs to process our docs.
- Generate `/llms.txt` post build. This builds a full site map in Markdown format. Example:

```
# DBOS Documentation

## Docs

- [DBOS Examples](https://docs.dbos.dev/examples/index.md): Example applications built with DBOS
- [How Workflows Work](https://docs.dbos.dev/explanations/how-workflows-work.md): Learn how DBOS workflows work
- [DBOS System Tables](https://docs.dbos.dev/explanations/system-tables.md): DBOS system tables reference
- [Troubleshooting & FAQ](https://docs.dbos.dev/faq.md): Where do I find the DBOS tables?
- [Welcome to DBOS!](https://docs.dbos.dev/index.md): DBOS is a library for building reliable programs.
...
```