### PR TITLE
document Golang db-backed schedules

### DIFF
--- a/docs/golang/prompting.md
+++ b/docs/golang/prompting.md
@@ -601,45 +601,50 @@ func workflow(ctx dbos.DBOSContext, _ string) (string, error) {
 
 ### Scheduled Workflows
 
-You can schedule workflows to run automatically at specified times using cron syntax with seconds precision.
+You can schedule workflows to run on a cron expression.
+Schedules are stored in the database and can be created, paused, resumed, and deleted at runtime.
 Scheduled workflows are useful for running recurring tasks like data backups, report generation, or cleanup operations.
 
-To create a scheduled workflow, use `WithSchedule` when registering your workflow.
-The workflow must have a single `time.Time` input parameter, representing the scheduled execution time.
-
-**Example syntax:**
+Scheduled workflows must accept a `dbos.ScheduledWorkflowInput`, which carries the cron tick time and a user-defined `Context` value attached to the schedule:
 
 ```go
-func frequentTask(ctx dbos.DBOSContext, scheduledTime time.Time) (string, error) {
-    fmt.Printf("Performing a scheduled task at: %s\n", scheduledTime.Format(time.RFC3339))
-    ... // Perform a scheduled task operations
-    return result, nil
+type ScheduledWorkflowInput struct {
+    ScheduledTime time.Time
+    Context       any
 }
+```
 
-func dailyBackup(ctx dbos.DBOSContext, scheduledTime time.Time) (string, error) {
-    fmt.Printf("Running daily backup at: %s\n", scheduledTime.Format(time.RFC3339))
+Register the workflow normally, then create a schedule for it using `dbos.CreateSchedule` (or `dbos.ApplySchedules` to declaratively apply a set of schedules on start):
+
+```go
+func dailyBackup(ctx dbos.DBOSContext, input dbos.ScheduledWorkflowInput) (any, error) {
+    fmt.Printf("Running daily backup at: %s\n", input.ScheduledTime.Format(time.RFC3339))
     ... // Perform daily backup operations
-    return result, nil
+    return nil, nil
 }
 
 func main() {
     dbosContext := ... // Initialize DBOS
 
-    // Register a workflow to run daily at 2:00 AM
-    dbos.RegisterWorkflow(dbosContext, dailyBackup,
-        dbos.WithSchedule("0 0 2 * * *")) // Cron: daily at 2:00 AM
+    dbos.RegisterWorkflow(dbosContext, dailyBackup)
 
-    // Register a workflow to run every 15 minutes
-    dbos.RegisterWorkflow(dbosContext, frequentTask,
-        dbos.WithSchedule("0 */15 * * * * ")) // Cron: every 15 minutes
-
-    // Launch DBOS - scheduled workflows will start automatically
     err := dbos.Launch(dbosContext)
+    if err != nil {
+        log.Fatal(err)
+    }
+
+    // Schedule the workflow to run daily at 2:00 AM
+    err = dbos.CreateSchedule(dbosContext, dailyBackup, dbos.CreateScheduleRequest{
+        ScheduleName: "daily-backup",
+        Schedule:     "0 0 2 * * *",
+    })
     if err != nil {
         log.Fatal(err)
     }
 }
 ```
+
+Schedules can also be paused, resumed, deleted, backfilled, and triggered at runtime with `dbos.PauseSchedule`, `dbos.ResumeSchedule`, `dbos.DeleteSchedule`, `dbos.BackfillSchedule`, and `dbos.TriggerSchedule`. By default, scheduled invocations are enqueued on an internal queue; pass `dbos.WithScheduleQueueName("...")` to route them to a declared queue for concurrency or rate-limit control.
 
 ### Workflow Versioning and Recovery
 
@@ -2194,16 +2199,6 @@ func WithMaxRetries(maxRetries int) WorkflowRegistrationOption
 Configure the maximum number of times execution of a workflow may be attempted.
 This acts as a dead letter queue so that a buggy workflow that crashes its application (for example, by running it out of memory) does not do so infinitely.
 If a workflow exceeds this limit, its status is set to `MAX_RECOVERY_ATTEMPTS_EXCEEDED` and it may no longer be executed.
-
-#### WithSchedule
-
-```go
-func WithSchedule(schedule string) WorkflowRegistrationOption
-```
-
-Registers the workflow as a scheduled workflow using cron syntax.
-The schedule string follows standard cron format with second precision.
-Scheduled workflows automatically receive a `time.Time` input parameter.
 
 #### WithWorkflowName
 

--- a/docs/golang/reference/client.md
+++ b/docs/golang/reference/client.md
@@ -27,6 +27,15 @@ type Client interface {
     GetWorkflowSteps(workflowID string) ([]StepInfo, error)
     ClientReadStream(workflowID string, key string) ([]any, bool, error)
     ClientReadStreamAsync(workflowID string, key string) (<-chan StreamValue[any], error)
+    CreateSchedule(input ClientScheduleInput) error
+    ApplySchedules(schedules []ClientScheduleInput) error
+    GetSchedule(scheduleName string) (*WorkflowSchedule, error)
+    ListSchedules(opts ...ListSchedulesOption) ([]WorkflowSchedule, error)
+    PauseSchedule(scheduleName string) error
+    ResumeSchedule(scheduleName string) error
+    DeleteSchedule(scheduleName string) error
+    BackfillSchedule(scheduleName string, start, end time.Time) ([]string, error)
+    TriggerSchedule(scheduleName string) (WorkflowHandle[any], error)
     Shutdown(timeout time.Duration)
 }
 ```
@@ -325,6 +334,109 @@ Behaves the same as [`Debouncer.Debounce`](./queues.md#debouncerdebounce) but do
 - `delay`: Time by which to delay workflow execution.
 - `input`: Input parameters to pass to the workflow.
 - `opts`: Optional workflow options.
+
+## Schedule Management
+
+`Client` exposes the same [workflow scheduling](./methods.md#workflow-schedules) operations as the DBOS context, with the important difference that workflows are identified by name (string) rather than by function reference.
+See the [scheduled workflows tutorial](../tutorials/scheduled-workflows.md) for an overview.
+
+### ClientScheduleInput
+
+```go
+type ClientScheduleInput struct {
+    ScheduleName      string // Required: unique schedule name
+    WorkflowName      string // Required: target workflow name (FQN or custom name)
+    WorkflowClassName string // Optional: class/namespace name (required for Python/TS/Java targets that dispatch by class)
+    Schedule          string // Required: cron expression
+    Context           any    // Optional: user-defined context (JSON-serialized)
+    AutomaticBackfill bool   // Optional
+    CronTimezone      string // Optional: IANA timezone name
+    QueueName         string // Optional: target queue
+}
+```
+
+### Client.CreateSchedule
+
+```go
+CreateSchedule(input ClientScheduleInput) error
+```
+
+Create a new schedule. Similar to [`CreateSchedule`](./methods.md#createschedule).
+
+**Example:**
+
+```go
+err := client.CreateSchedule(dbos.ClientScheduleInput{
+    ScheduleName: "my-schedule",
+    WorkflowName: "myPeriodicTask",
+    Schedule:     "*/5 * * * *",
+    Context:      "my context",
+})
+```
+
+### Client.ApplySchedules
+
+```go
+ApplySchedules(schedules []ClientScheduleInput) error
+```
+
+Atomically create or replace the given schedules. Similar to [`ApplySchedules`](./methods.md#applyschedules).
+
+### Client.GetSchedule
+
+```go
+GetSchedule(scheduleName string) (*WorkflowSchedule, error)
+```
+
+Retrieve a [`WorkflowSchedule`](./methods.md#workflowschedule) by name. Returns `(nil, nil)` if not found.
+
+### Client.ListSchedules
+
+```go
+ListSchedules(opts ...ListSchedulesOption) ([]WorkflowSchedule, error)
+```
+
+List schedules, optionally filtered. Accepts the same options as [`ListSchedules`](./methods.md#listschedules).
+
+### Client.PauseSchedule
+
+```go
+PauseSchedule(scheduleName string) error
+```
+
+Pause a schedule so it stops firing.
+
+### Client.ResumeSchedule
+
+```go
+ResumeSchedule(scheduleName string) error
+```
+
+Resume a paused schedule.
+
+### Client.DeleteSchedule
+
+```go
+DeleteSchedule(scheduleName string) error
+```
+
+Delete a schedule.
+
+### Client.BackfillSchedule
+
+```go
+BackfillSchedule(scheduleName string, start, end time.Time) ([]string, error)
+```
+
+Backfill missed executions for the range `[start, end]`, returning the IDs of the enqueued workflows. Similar to [`BackfillSchedule`](./methods.md#backfillschedule).
+
+### Client.TriggerSchedule
+
+```go
+TriggerSchedule(scheduleName string) (WorkflowHandle[any], error)
+```
+
+Trigger a schedule to fire immediately, returning a handle for the enqueued workflow.
 
 ## Stream Methods
 

--- a/docs/golang/reference/dbos-context.md
+++ b/docs/golang/reference/dbos-context.md
@@ -55,7 +55,7 @@ dbos.Launch(ctx DBOSContext) error
 
 Launch the following resources managed by a `DBOSContext`:
 - A [system database connection pool](../../explanations/system-tables.md)
-- A [workflow scheduler](../tutorials/workflow-tutorial.md#scheduled-workflows)
+- A [workflow scheduler](../tutorials/scheduled-workflows.md)
 - A [workflow queue runner](../tutorials/queue-tutorial.md)
 - (Optionally) an admin server
 - (Optionally) a Conductor connection

--- a/docs/golang/reference/methods.md
+++ b/docs/golang/reference/methods.md
@@ -518,6 +518,263 @@ const (
 )
 ```
 
+## Workflow Schedules
+
+DBOS lets you schedule workflows to run on a cron expression.
+Schedules are stored in the database and can be created, paused, resumed, and deleted at runtime.
+See the [scheduled workflows tutorial](../tutorials/scheduled-workflows.md) for an overview.
+
+Scheduled workflows must accept a [`ScheduledWorkflowInput`](#scheduledworkflowinput) as their input parameter.
+
+### ScheduledWorkflowInput
+
+```go
+type ScheduledWorkflowInput struct {
+    ScheduledTime time.Time // The cron tick time
+    Context       any       // The user-defined context attached to the schedule (nil if none)
+}
+```
+
+The input type of a scheduled workflow function. `Context` is JSON-serialized when stored and decoded into an `any` value when the workflow fires; type-assert or unmarshal it inside the workflow.
+
+### WorkflowSchedule
+
+```go
+type WorkflowSchedule struct {
+    ScheduleID        string         // Unique ID assigned to this schedule revision
+    ScheduleName      string         // User-supplied unique name
+    WorkflowName      string         // Fully-qualified or custom name of the workflow
+    WorkflowClassName string         // Class/namespace (used for cross-language dispatch)
+    Schedule          string         // Cron expression
+    Status            ScheduleStatus // ACTIVE or PAUSED
+    Context           any            // User-defined context attached to the schedule
+    LastFiredAt       *time.Time     // Last time the schedule fired (nil if never)
+    AutomaticBackfill bool           // Whether to backfill missed ticks on application start
+    CronTimezone      string         // IANA timezone name (empty for UTC)
+    QueueName         string         // Queue on which scheduled workflows are enqueued
+}
+```
+
+#### ScheduleStatus
+
+```go
+type ScheduleStatus string
+
+const (
+    ScheduleStatusActive ScheduleStatus = "ACTIVE" // Schedule is firing
+    ScheduleStatusPaused ScheduleStatus = "PAUSED" // Schedule is paused
+)
+```
+
+### CreateSchedule
+
+```go
+func CreateSchedule(ctx DBOSContext, fn ScheduledWorkflowFunc, input CreateScheduleRequest, opts ...CreateScheduleOption) error
+```
+
+Create a new schedule for a registered workflow.
+Fails if a schedule with the same name already exists.
+The reconciler loop picks the new schedule up on its next tick and installs it in the cron scheduler.
+
+The workflow function `fn` must be already registered via [`RegisterWorkflow`](./workflows-steps.md#registerworkflow) and must conform to:
+
+```go
+type ScheduledWorkflowFunc func(ctx DBOSContext, input ScheduledWorkflowInput) (any, error)
+```
+
+**Parameters:**
+- **ctx**: The DBOS context.
+- **fn**: The scheduled workflow function reference.
+- **input**: A [`CreateScheduleRequest`](#createschedulerequest) with the schedule name and cron expression.
+- **opts**: Optional schedule configuration, documented below.
+
+#### CreateScheduleRequest
+
+```go
+type CreateScheduleRequest struct {
+    ScheduleName string // Unique name of the schedule
+    Schedule     string // Cron expression
+}
+```
+
+#### WithScheduleContext
+
+```go
+func WithScheduleContext(context any) CreateScheduleOption
+```
+
+Attach a user-defined value (serialized as JSON) that is passed to each scheduled invocation as `ScheduledWorkflowInput.Context`.
+
+#### WithAutomaticBackfill
+
+```go
+func WithAutomaticBackfill(enabled bool) CreateScheduleOption
+```
+
+Enable automatic backfill of missed ticks when the schedule is reloaded after downtime (or when a paused schedule is resumed).
+
+#### WithCronTimezone
+
+```go
+func WithCronTimezone(tz string) CreateScheduleOption
+```
+
+Interpret the cron expression in the given [IANA timezone](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones) (e.g. `"America/New_York"`). Defaults to UTC.
+
+#### WithScheduleQueueName
+
+```go
+func WithScheduleQueueName(name string) CreateScheduleOption
+```
+
+Route each scheduled invocation to the named [queue](./queues.md) instead of the default internal queue.
+
+#### WithScheduleWorkflowClassName
+
+```go
+func WithScheduleWorkflowClassName(name string) CreateScheduleOption
+```
+
+Record a class/namespace name on the schedule for cross-language dispatch.
+Use this when the scheduled workflow is owned by a non-Go runtime (e.g. a Python class-based workflow) so the stored schedule carries the correct class name.
+
+**Example:**
+
+```go
+err := dbos.CreateSchedule(ctx, myPeriodicTask, dbos.CreateScheduleRequest{
+    ScheduleName: "my-schedule",
+    Schedule:     "*/5 * * * *",
+},
+    dbos.WithScheduleContext("my context"),
+    dbos.WithAutomaticBackfill(true),
+)
+```
+
+### ApplySchedules
+
+```go
+func ApplySchedules(ctx DBOSContext, schedules []ApplySchedulesRequest) error
+```
+
+Atomically create or replace a list of schedules in a single transaction.
+For each entry, any existing schedule with the same name is deleted before the new schedule is inserted.
+Useful for defining a fixed set of static schedules on application start.
+
+`ApplySchedules` cannot be called from within a workflow.
+
+```go
+type ApplySchedulesRequest struct {
+    ScheduleName      string // Required
+    WorkflowFn        any    // Required: a registered scheduled workflow function
+    Schedule          string // Required: cron expression
+    Context           any    // Optional: user-defined context (JSON-serialized)
+    AutomaticBackfill bool   // Optional
+    CronTimezone      string // Optional: IANA timezone name
+    QueueName         string // Optional: target queue
+}
+```
+
+**Example:**
+
+```go
+err := dbos.ApplySchedules(ctx, []dbos.ApplySchedulesRequest{
+    {ScheduleName: "a", WorkflowFn: workflowA, Schedule: "*/10 * * * *"},
+    {ScheduleName: "b", WorkflowFn: workflowB, Schedule: "0 0 * * *"},
+})
+```
+
+### GetSchedule
+
+```go
+func GetSchedule(ctx DBOSContext, scheduleName string) (*WorkflowSchedule, error)
+```
+
+Retrieve a [`WorkflowSchedule`](#workflowschedule) by name. Returns `(nil, nil)` if no schedule with that name exists.
+
+### ListSchedules
+
+```go
+func ListSchedules(ctx DBOSContext, opts ...ListSchedulesOption) ([]WorkflowSchedule, error)
+```
+
+List schedules, optionally filtered. Pass no options to return all schedules.
+
+#### WithScheduleStatuses
+
+```go
+func WithScheduleStatuses(statuses ...ScheduleStatus) ListSchedulesOption
+```
+
+Filter by one or more [`ScheduleStatus`](#schedulestatus) values.
+
+#### WithScheduleWorkflowNames
+
+```go
+func WithScheduleWorkflowNames(names ...string) ListSchedulesOption
+```
+
+Filter by workflow name(s). Use the fully qualified name or the custom name registered via [`WithWorkflowName`](./workflows-steps.md#withworkflowname).
+
+#### WithScheduleNamePrefixes
+
+```go
+func WithScheduleNamePrefixes(prefixes ...string) ListSchedulesOption
+```
+
+Filter by schedule name prefix(es).
+
+### PauseSchedule
+
+```go
+func PauseSchedule(ctx DBOSContext, scheduleName string) error
+```
+
+Pause a schedule so it stops firing. The schedule's cron entry is removed on the next reconciler tick.
+
+### ResumeSchedule
+
+```go
+func ResumeSchedule(ctx DBOSContext, scheduleName string) error
+```
+
+Resume a paused schedule. If the schedule was created with [`WithAutomaticBackfill(true)`](#withautomaticbackfill), missed ticks during the pause are backfilled.
+
+### DeleteSchedule
+
+```go
+func DeleteSchedule(ctx DBOSContext, scheduleName string) error
+```
+
+Delete a schedule. The schedule's cron entry is removed on the next reconciler tick.
+
+### BackfillSchedule
+
+```go
+func BackfillSchedule(ctx DBOSContext, scheduleName string, start, end time.Time) ([]string, error)
+```
+
+Backfill missed executions for the range `[start, end]`, returning the IDs of the enqueued workflows.
+Already-executed ticks are automatically skipped, so it is safe to overlap ranges.
+Cannot be called from within a workflow.
+
+**Example:**
+
+```go
+ids, err := dbos.BackfillSchedule(ctx, "my-schedule",
+    time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
+    time.Date(2025, 1, 2, 0, 0, 0, 0, time.UTC),
+)
+```
+
+### TriggerSchedule
+
+```go
+func TriggerSchedule(ctx DBOSContext, scheduleName string) (WorkflowHandle[any], error)
+```
+
+Trigger a schedule to fire immediately and return a [`WorkflowHandle`](./workflows-steps.md#workflowhandle) for the enqueued workflow.
+Cannot be called from within a workflow.
+
 ## DBOS Variables
 
 ### GetWorkflowID

--- a/docs/golang/reference/workflows-steps.md
+++ b/docs/golang/reference/workflows-steps.md
@@ -44,16 +44,6 @@ dbos.RegisterWorkflow(dbosContext, myWorkflow, dbos.WithMaxRetries(3))
 The `Attempts` field in [`WorkflowStatus`](./methods.md#workflow-status) tracks how many times a workflow has been executed: `1` on first execution, `0` if enqueued but not yet dequeued, and incremented by `1` on each recovery or dequeue. The attempt count is incremented one last time before a workflow is placed in the DLQ&mdash;for example, a workflow with max retries of 1 that has been moved to the DLQ will show 3 attempts.
 :::
 
-#### WithSchedule
-
-```go
-func WithSchedule(schedule string) WorkflowRegistrationOption
-```
-
-Registers the workflow as a scheduled workflow using cron syntax.
-The schedule string follows standard cron format with second precision.
-Scheduled workflows automatically receive a `time.Time` input parameter. 
-
 #### WithWorkflowName
 
 ```go

--- a/docs/golang/tutorials/scheduled-workflows.md
+++ b/docs/golang/tutorials/scheduled-workflows.md
@@ -1,0 +1,179 @@
+---
+sidebar_position: 60
+title: Scheduling Workflows
+---
+
+You can schedule DBOS [workflows](./workflow-tutorial.md) to run on a cron schedule.
+Schedules are stored in the database and can be created, paused, resumed, and deleted at runtime.
+
+To schedule a workflow, first define a workflow whose input is a [`ScheduledWorkflowInput`](../reference/methods.md#scheduledworkflowinput).
+This struct carries the cron tick time (`ScheduledTime`) and a user-defined `Context` value attached to the schedule:
+
+```go
+func myPeriodicTask(ctx dbos.DBOSContext, input dbos.ScheduledWorkflowInput) (any, error) {
+    logger.Info("running scheduled task",
+        "scheduled_time", input.ScheduledTime,
+        "context", input.Context)
+    return nil, nil
+}
+
+dbos.RegisterWorkflow(dbosContext, myPeriodicTask)
+```
+
+Then, create a schedule for it using [`CreateSchedule`](../reference/methods.md#createschedule) with a [crontab](https://en.wikipedia.org/wiki/Cron) expression:
+
+```go
+err := dbos.CreateSchedule(dbosContext, myPeriodicTask, dbos.CreateScheduleRequest{
+    ScheduleName: "my-task-schedule", // The schedule name is a unique identifier of the schedule
+    Schedule:     "*/5 * * * *",      // Every 5 minutes
+}, dbos.WithScheduleContext("my context")) // The context is passed into every iteration of the workflow
+```
+
+Note that `CreateSchedule` will fail if the schedule already exists.
+If you're defining a set of static schedules to be created on program start, you can instead use [`ApplySchedules`](../reference/methods.md#applyschedules) to create them atomically, updating them if they already exist:
+
+```go
+err := dbos.ApplySchedules(dbosContext, []dbos.ApplySchedulesRequest{
+    {
+        ScheduleName: "schedule-a",
+        WorkflowFn:   workflowA,
+        Schedule:     "*/10 * * * *", // Every 10 minutes
+        Context:      "context-a",
+    },
+    {
+        ScheduleName: "schedule-b",
+        WorkflowFn:   workflowB,
+        Schedule:     "0 0 * * *",    // Every day at midnight
+        Context:      "context-b",
+    },
+})
+```
+
+To learn more about crontab syntax, see [this guide](https://docs.gitlab.com/ee/topics/cron/) or [this crontab editor](https://crontab.guru/).
+DBOS Go uses [robfig/cron](https://pkg.go.dev/github.com/robfig/cron/v3) to parse cron schedules, with seconds as an optional first field.
+Valid cron schedules contain 5 or 6 items, separated by spaces:
+
+```
+ ┌────────────── second (optional)
+ │ ┌──────────── minute
+ │ │ ┌────────── hour
+ │ │ │ ┌──────── day of month
+ │ │ │ │ ┌────── month
+ │ │ │ │ │ ┌──── day of week
+ │ │ │ │ │ │
+ │ │ │ │ │ │
+ * * * * * *
+```
+
+Cron expressions are evaluated in UTC by default. Pass [`WithCronTimezone`](../reference/methods.md#withcrontimezone) with an [IANA timezone name](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones) (e.g. `"America/New_York"`) to evaluate the expression in a different timezone.
+
+You can dynamically create many schedules for the same workflow.
+For example, if you want to perform certain actions periodically for each of your customers, you can create one schedule per customer, using customer ID as context so each workflow knows which customer to act on:
+
+```go
+func customerWorkflow(ctx dbos.DBOSContext, input dbos.ScheduledWorkflowInput) (any, error) {
+    customerID := input.Context.(string)
+    // ...
+    return nil, nil
+}
+
+dbos.RegisterWorkflow(dbosContext, customerWorkflow)
+
+func onCustomerRegistration(ctx dbos.DBOSContext, customerID string) error {
+    return dbos.CreateSchedule(ctx, customerWorkflow, dbos.CreateScheduleRequest{
+        ScheduleName: fmt.Sprintf("customer-%s-sync", customerID),
+        Schedule:     "0 * * * *", // Every hour
+    }, dbos.WithScheduleContext(customerID))
+}
+```
+
+The `Context` field on `ScheduledWorkflowInput` is typed as `any` and is serialized as JSON.
+Type-assert or unmarshal it inside the workflow to recover the original value.
+
+### Managing Schedules
+
+You can pause, resume, and delete schedules at runtime:
+
+```go
+// Pause a schedule so it stops firing
+err := dbos.PauseSchedule(dbosContext, "my-task-schedule")
+
+// Resume a paused schedule
+err = dbos.ResumeSchedule(dbosContext, "my-task-schedule")
+
+// Delete a schedule
+err = dbos.DeleteSchedule(dbosContext, "my-task-schedule")
+```
+
+You can also list and inspect schedules:
+
+```go
+// List all active schedules
+schedules, err := dbos.ListSchedules(dbosContext,
+    dbos.WithScheduleStatuses(dbos.ScheduleStatusActive))
+
+// Get a specific schedule by name
+schedule, err := dbos.GetSchedule(dbosContext, "my-task-schedule")
+```
+
+### Backfilling and Triggering
+
+If a schedule was paused or your application was offline, you can backfill missed executions using [`BackfillSchedule`](../reference/methods.md#backfillschedule).
+Already-executed times are automatically skipped:
+
+```go
+start := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+end := time.Date(2025, 1, 2, 0, 0, 0, 0, time.UTC)
+ids, err := dbos.BackfillSchedule(dbosContext, "my-task-schedule", start, end)
+```
+
+Alternatively, pass [`WithAutomaticBackfill(true)`](../reference/methods.md#withautomaticbackfill) when creating a schedule so that missed executions are automatically backfilled whenever your application starts or a paused schedule is resumed.
+
+You can also immediately trigger a schedule using [`TriggerSchedule`](../reference/methods.md#triggerschedule):
+
+```go
+handle, err := dbos.TriggerSchedule(dbosContext, "my-task-schedule")
+```
+
+### Scheduling to Queues
+
+By default, scheduled workflows are enqueued on an internal queue.
+You can instead enqueue them on a declared [queue](./queue-tutorial.md) to manage their concurrency or rate limits.
+Pass [`WithScheduleQueueName`](../reference/methods.md#withschedulequeuename) when creating the schedule:
+
+```go
+dbos.NewWorkflowQueue(dbosContext, "scheduled_queue",
+    dbos.WithGlobalConcurrency(1))
+
+err := dbos.CreateSchedule(dbosContext, myPeriodicTask, dbos.CreateScheduleRequest{
+    ScheduleName: "my-task-schedule",
+    Schedule:     "*/5 * * * *",
+}, dbos.WithScheduleQueueName("scheduled_queue"))
+```
+
+This ensures that scheduled workflow executions respect the queue's flow control settings.
+
+### Managing Schedules from Another Application
+
+You can manage schedules from outside your DBOS application using the [DBOS Client](../reference/client.md#schedule-management).
+The client accepts workflow names as strings instead of function references:
+
+```go
+client, err := dbos.NewClient(context.Background(), dbos.ClientConfig{
+    DatabaseURL: os.Getenv("DBOS_SYSTEM_DATABASE_URL"),
+})
+
+err = client.CreateSchedule(dbos.ClientScheduleInput{
+    ScheduleName: "my-task-schedule",
+    WorkflowName: "myPeriodicTask",
+    Schedule:     "*/5 * * * *",
+    Context:      "my context",
+})
+```
+
+### How Scheduling Works
+
+Under the hood, DBOS constructs an [idempotency key](./workflow-tutorial.md#workflow-ids-and-idempotency) for each scheduled workflow execution.
+The key is the concatenation of `sched-`, the schedule name, and the scheduled time (RFC3339), ensuring each scheduled invocation occurs exactly once even when multiple application instances share the same schedule.
+
+For the full API reference, see [Workflow Schedules](../reference/methods.md#workflow-schedules).

--- a/docs/golang/tutorials/workflow-tutorial.md
+++ b/docs/golang/tutorials/workflow-tutorial.md
@@ -213,45 +213,9 @@ func exampleWorkflow(ctx dbos.DBOSContext, input struct {
 
 ## Scheduled Workflows
 
-You can schedule workflows to run automatically at specified times using cron syntax with seconds precision.
-Scheduled workflows are useful for running recurring tasks like data backups, report generation, or cleanup operations.
-
-To create a scheduled workflow, use [`WithSchedule`](../reference/workflows-steps#withschedule) when registering your workflow.
-The workflow must have a single [`time.Time`](https://pkg.go.dev/time#Time) input parameter, representing the scheduled execution time.
-
-**Example syntax:**
-
-```go
-func frequentTask(ctx dbos.DBOSContext, scheduledTime time.Time) (string, error) {
-    fmt.Printf("Performing a scheduled task at: %s\n", scheduledTime.Format(time.RFC3339))
-    ... // Perform a scheduled task operations
-    return result, nil
-}
-
-func dailyBackup(ctx dbos.DBOSContext, scheduledTime time.Time) (string, error) {
-    fmt.Printf("Running daily backup at: %s\n", scheduledTime.Format(time.RFC3339))
-    ... // Perform daily backup operations
-    return result, nil
-}
-
-func main() {
-    dbosContext := ... // Initialize DBOS
-
-    // Register a workflow to run daily at 2:00 AM
-    dbos.RegisterWorkflow(dbosContext, dailyBackup, 
-        dbos.WithSchedule("0 0 2 * * *")) // Cron: daily at 2:00 AM
-    
-    // Register a workflow to run every 15 minutes
-    dbos.RegisterWorkflow(dbosContext, frequentTask,
-        dbos.WithSchedule("0 */15 * * * * ")) // Cron: every 15 minutes
-    
-    // Launch DBOS - scheduled workflows will start automatically
-    err := dbos.Launch(dbosContext)
-    if err != nil {
-        log.Fatal(err)
-    }
-}
-```
+You can schedule workflows to run on a cron expression.
+Schedules are stored in the database and can be created, paused, resumed, and deleted at runtime.
+See the [scheduled workflows tutorial](./scheduled-workflows.md) for details.
 
 ## Debouncing
 

--- a/docs/production/hosting-with-cloud-run.md
+++ b/docs/production/hosting-with-cloud-run.md
@@ -31,7 +31,7 @@ A [Cloud Run worker pool](https://cloud.google.com/run/docs/overview/what-is-clo
 
 Worker pools suit DBOS applications that rely heavily on queues. Every instance actively dequeues and processes workflows, and the pool can be resized via the [Cloud Run REST API](https://docs.cloud.google.com/run/docs/reference/rest).
 
-Worker pools don't auto-scale, but you can implement an **external scaler** from within the pool. Use a DBOS [scheduled workflow](../golang/tutorials/workflow-tutorial.md#scheduled-workflows) that periodically checks queue length with [`ListWorkflows`](../golang/reference/client.md) and calls the [Cloud Run Admin API](https://cloud.google.com/run/docs/reference/rest/v2/projects.locations.workerPools) to resize the pool based on load.
+Worker pools don't auto-scale, but you can implement an **external scaler** from within the pool. Use a DBOS [scheduled workflow](../golang/tutorials/scheduled-workflows.md) that periodically checks queue length with [`ListWorkflows`](../golang/reference/client.md) and calls the [Cloud Run Admin API](https://cloud.google.com/run/docs/reference/rest/v2/projects.locations.workerPools) to resize the pool based on load.
 This works _even from within the pool_ because DBOS guarantees only one process runs a scheduled function at a time, even across multiple instances. This prevents a thundering herd of conflicting resize requests.
 
 See [Scaling a worker pool](#scaling-a-worker-pool) below for a full walkthrough.
@@ -40,7 +40,7 @@ See [Scaling a worker pool](#scaling-a-worker-pool) below for a full walkthrough
 
 A [Cloud Run job](https://cloud.google.com/run/docs/overview/what-is-cloud-run#jobs) runs a container to completion and exits without listening for HTTP requests.
 
-Because DBOS has a [built-in scheduler](../golang/tutorials/workflow-tutorial.md#scheduled-workflows), you typically don't need Cloud Run Jobs. However, Jobs suit applications that consist entirely of periodic work with no always-on requirement&mdash;the job starts, runs workflows to completion, and shuts down, so you only pay for the time it runs.
+Because DBOS has a [built-in scheduler](../golang/tutorials/scheduled-workflows.md), you typically don't need Cloud Run Jobs. However, Jobs suit applications that consist entirely of periodic work with no always-on requirement&mdash;the job starts, runs workflows to completion, and shuts down, so you only pay for the time it runs.
 
 ## Deploying to Cloud Run
 
@@ -360,7 +360,7 @@ Returns `1`, `2`, or `3` depending on how many steps have completed.
 
 ## Scaling a Worker Pool
 
-Worker pools don't auto-scale, but you can build an **external scaler** inside the pool using a DBOS [scheduled workflow](../golang/tutorials/workflow-tutorial.md#scheduled-workflows). DBOS guarantees only one instance runs a scheduled function at a time&mdash;even across a multi-instance pool&mdash;preventing a thundering herd of conflicting resize requests.
+Worker pools don't auto-scale, but you can build an **external scaler** inside the pool using a DBOS [scheduled workflow](../golang/tutorials/scheduled-workflows.md). DBOS guarantees only one instance runs a scheduled function at a time&mdash;even across a multi-instance pool&mdash;preventing a thundering herd of conflicting resize requests.
 
 The complete implementation is in the [cloud-run demo app](https://github.com/dbos-inc/dbos-demo-apps/tree/main/golang/cloudrun).
 
@@ -396,7 +396,7 @@ Here's an example in Go (the same approach works in any DBOS-supported language)
 <summary><strong>Scaling workflow snippet</strong></summary>
 
 ```go title="main.go"
-func ScalingWorkflow(ctx dbos.DBOSContext, scheduledTime time.Time) (string, error) {
+func ScalingWorkflow(ctx dbos.DBOSContext, input dbos.ScheduledWorkflowInput) (any, error) {
     // 1. Read queue length by listing all enqueued/pending workflows
     workflows, err := dbos.ListWorkflows(ctx, dbos.WithQueuesOnly(), dbos.WithQueueName(taskQueue.Name))
     if err != nil {


### PR DESCRIPTION
Remove docs for now-deprecated in-memory Golang schedules.