### PR TITLE
Fix self bean name

### DIFF
--- a/docs/java/tutorials/spring-boot-integration.md
+++ b/docs/java/tutorials/spring-boot-integration.md
@@ -109,7 +109,7 @@ public class OrderService {
   // self reference is injected automatically by Spring Boot Dependency Injection
   @Autowired 
   @Lazy
-  public void setSelf(WidgetStoreService self) {
+  public void setSelf(OrderService self) {
     this.self = self;
   }
 


### PR DESCRIPTION
Self reference should be of the same type as that of the service i.e. `OrderService` & not of type `WidgetStoreService`. This PR fixes the documentation to specify correct bean name for `self`