### PR TITLE
Better queue example with worker concurrency

### DIFF
--- a/docs/java/tutorials/queue-tutorial.md
+++ b/docs/java/tutorials/queue-tutorial.md
@@ -430,9 +430,9 @@ For example:
 
 ```java
 // By using two levels of queueing, we enforce both a concurrency limit of 1 on each partition
-// and a global concurrency limit of 5, meaning that no more than 5 tasks can run concurrently
+// and a worker concurrency limit of 5, meaning that no more than 5 tasks can run per worker
 // across all partitions (and at most one task per partition).
-DBOS.registerQueue("concurrency-queue", QueueOptions.setConcurrency(5));
+DBOS.registerQueue("concurrency-queue", QueueOptions.setWorkerConcurrency(5));
 DBOS.registerQueue("partitioned-queue",
     QueueOptions.setConcurrency(1).andPartitionQueue(true));
 

--- a/docs/python/prompting.md
+++ b/docs/python/prompting.md
@@ -1085,9 +1085,9 @@ For example:
 
 ```python
 # By using two levels of queueing, we enforce both a concurrency limit of 1 on each partition
-# and a global concurrency limit of 5, meaning that no more than 5 tasks can run concurrently
+# and a worker concurrency limit of 5, meaning that no more than 5 tasks can run per worker
 # across all partitions (and at most one task per partition).
-DBOS.register_queue("concurrency-queue", concurrency=5)
+DBOS.register_queue("concurrency-queue", worker_concurrency=5)
 DBOS.register_queue("partitioned-queue", partition_queue=True, concurrency=1)
 
 def on_user_task_submission(user_id: str, task: Task):

--- a/docs/python/tutorials/queue-tutorial.md
+++ b/docs/python/tutorials/queue-tutorial.md
@@ -278,9 +278,9 @@ For example:
 
 ```python
 # By using two levels of queueing, we enforce both a concurrency limit of 1 on each partition
-# and a global concurrency limit of 5, meaning that no more than 5 tasks can run concurrently
+# and a worker concurrency limit of 5, meaning that no more than 5 tasks can run per worker
 # across all partitions (and at most one task per partition).
-DBOS.register_queue("concurrency-queue", concurrency=5)
+DBOS.register_queue("concurrency-queue", worker_concurrency=5)
 DBOS.register_queue("partitioned-queue", partition_queue=True, concurrency=1)
 
 def on_user_task_submission(user_id: str, task: Task):

--- a/docs/typescript/prompting.md
+++ b/docs/typescript/prompting.md
@@ -1152,9 +1152,9 @@ For example:
 
 ```ts
 // By using two levels of queueing, we enforce both a concurrency limit of 1 on each partition
-// and a global concurrency limit of 5, meaning that no more than 5 tasks can run concurrently
+// and a worker concurrency limit of 5, meaning that no more than 5 tasks can run per worker
 // across all partitions (and at most one task per partition).
-await DBOS.registerQueue("concurrency-queue", { concurrency: 5 });
+await DBOS.registerQueue("concurrency-queue", { workerConcurrency: 5 });
 await DBOS.registerQueue("partitioned-queue", { partitionQueue: true, concurrency: 1 });
 
 async function onUserTaskSubmission(userID: string, task: Task) {

--- a/docs/typescript/tutorials/queue-tutorial.md
+++ b/docs/typescript/tutorials/queue-tutorial.md
@@ -323,9 +323,9 @@ For example:
 
 ```ts
 // By using two levels of queueing, we enforce both a concurrency limit of 1 on each partition
-// and a global concurrency limit of 5, meaning that no more than 5 tasks can run concurrently
+// and a worker concurrency limit of 5, meaning that no more than 5 tasks can run per worker
 // across all partitions (and at most one task per partition).
-await DBOS.registerQueue("concurrency-queue", { concurrency: 5 });
+await DBOS.registerQueue("concurrency-queue", { workerConcurrency: 5 });
 await DBOS.registerQueue("partitioned-queue", { partitionQueue: true, concurrency: 1 });
 
 async function onUserTaskSubmission(userID: string, task: Task) {


### PR DESCRIPTION
Change the partitioned /nested queue example to match what we see in the field most often