### PR TITLE
Go v0.20.0 notes

### DIFF
--- a/docs/golang/prompting.md
+++ b/docs/golang/prompting.md
@@ -49,6 +49,7 @@ If a workflow is interrupted for any reason (e.g., an executor restarts or crash
 - Do NOT make functions steps unless they are DIRECTLY called by a workflow.
 - If the workflow function performs a non-deterministic action, you MUST move that action to its own function and make that function a step. Examples of non-deterministic actions include accessing an external API or service, accessing files on disk, generating a random number, of getting the current time.
 - Do NOT start goroutines from workflows or use select in workflows. Instead, use DBOS's durable `dbos.Go` and `dbos.Select` functions which provide deterministic replay. For more complex parallel execution, use DBOS.RunWorkflow and DBOS queues.
+- Do NOT range over a map to call steps or start workflows: Go map iteration order is random, which breaks determinism. Sort the keys first (e.g. `slices.Sorted(maps.Keys(m))`) and iterate over the sorted slice.
 - DBOS workflows and steps should NOT have side effects in memory outside of their own scope. They can access global variables, but they should NOT create or update global variables or variables outside their scope.
 - Do NOT call any DBOS context method (DBOS.Send, DBOS.Recv, DBOS.RunWorkflow, DBOS.RunAsStep, DBOS.Sleep, DBOS.SetEvent, DBOS.GetEvent) from a step.
 
@@ -481,6 +482,8 @@ Instead, you should do all non-deterministic operations in steps.
 
 :::warning
 Go's goroutine scheduler and `select` operation are non-deterministic. You should use them only inside steps, or use the durable `dbos.Go` and `dbos.Select` functions instead.
+
+Go's map iteration order is also random. Don't call steps or start workflows while ranging over a map: sort the keys first (e.g. `slices.Sorted(maps.Keys(m))`) and iterate over the sorted slice.
 :::
 
 For example, **don't do this**:

--- a/docs/golang/reference/client.md
+++ b/docs/golang/reference/client.md
@@ -27,6 +27,7 @@ type Client interface {
     ResumeWorkflow(workflowID string, opts ...ResumeWorkflowOption) (WorkflowHandle[any], error)
     ResumeWorkflows(workflowIDs []string, opts ...ResumeWorkflowOption) ([]WorkflowHandle[any], error)
     ForkWorkflow(input ForkWorkflowInput) (WorkflowHandle[any], error)
+    ForkWorkflows(input ForkWorkflowsInput) ([]WorkflowHandle[any], error)
     ListApplicationVersions() ([]VersionInfo, error)
     GetLatestApplicationVersion() (*VersionInfo, error)
     SetLatestApplicationVersion(versionName string) error
@@ -46,7 +47,7 @@ type Client interface {
 }
 ```
 
-Several methods returning `WorkflowHandle[any]` have generic package-level counterparts (`ClientRetrieveWorkflow`, `ClientResumeWorkflow`, `ClientResumeWorkflows`, `ClientForkWorkflow`, `ClientTriggerSchedule`, `ClientGetEvent`) that return typed handles or values, documented alongside each method below.
+Several methods returning `WorkflowHandle[any]` have generic package-level counterparts (`ClientRetrieveWorkflow`, `ClientResumeWorkflow`, `ClientResumeWorkflows`, `ClientForkWorkflow`, `ClientForkWorkflows`, `ClientTriggerSchedule`, `ClientGetEvent`) that return typed handles or values, documented alongside each method below.
 
 ### Constructor
 
@@ -356,6 +357,19 @@ func ClientForkWorkflow[R any](c Client, input ForkWorkflowInput) (WorkflowHandl
 Set `QueueName` on the input to enqueue the forked workflow on a named queue instead of starting it immediately.
 The generic `ClientForkWorkflow` returns a typed handle whose `GetResult` decodes the forked workflow's output into type `R`.
 Similar to [`ForkWorkflow`](./methods.md#forkworkflow).
+
+### ForkWorkflows
+
+```go
+ForkWorkflows(input ForkWorkflowsInput) ([]WorkflowHandle[any], error)
+
+func ClientForkWorkflows[R any](c Client, input ForkWorkflowsInput) ([]WorkflowHandle[R], error)
+```
+
+Fork a batch of workflows in a single database round-trip.
+The returned handles are in the same order as `input.Workflows`.
+The generic `ClientForkWorkflows` returns typed handles whose `GetResult` decodes each forked workflow's output into type `R`.
+Similar to [`ForkWorkflows`](./methods.md#forkworkflows).
 
 ### Debouncer
 

--- a/docs/golang/reference/methods.md
+++ b/docs/golang/reference/methods.md
@@ -404,6 +404,15 @@ func WithHasParent(hasParent bool) ListWorkflowsOption
 
 Filter workflows by whether they have a parent workflow (true) or not (false).
 
+#### WithFilterScheduleName
+
+```go
+func WithFilterScheduleName(scheduleName ...string) ListWorkflowsOption
+```
+
+Filter workflows by the name(s) of the [schedule](#workflow-schedules) that enqueued them.
+Only workflows enqueued by a named schedule match.
+
 ### GetWorkflowSteps
 
 ```go
@@ -706,6 +715,49 @@ type ForkWorkflowInput struct {
 If `QueueName` is set, the forked workflow is enqueued on the specified queue instead of starting immediately.
 Set `QueuePartitionKey` together with `QueueName` to enqueue the forked workflow onto a specific partition of a [partitioned queue](../tutorials/queue-tutorial.md#partitioning-queues).
 
+### ForkWorkflows
+
+```go
+func ForkWorkflows[R any](ctx DBOSContext, input ForkWorkflowsInput) ([]WorkflowHandle[R], error)
+```
+
+Fork a batch of workflows in a single database round-trip.
+Each forked workflow gets a new UUID (unless a custom `ForkedWorkflowID` is provided) and executes from its specified `StartStep`, reusing the operation outputs of steps `0` to `StartStep-1` copied from the original workflow.
+The returned handles are in the same order as `input.Workflows`.
+
+**Parameters:**
+- **ctx**: The DBOS context.
+- **input**: A `ForkWorkflowsInput` struct where `Workflows` is mandatory.
+
+```go
+type ForkWorkflowsInput struct {
+    Workflows          []ForkWorkflowSpec // Required: The workflows to fork
+    ApplicationVersion string             // Optional: Application version for the forked workflows (inherits from originals if empty)
+    QueueName          string             // Optional: Queue to enqueue the forked workflows on (defaults to the internal queue)
+    QueuePartitionKey  string             // Optional: Partition key when enqueueing the forked workflows onto a partitioned queue
+}
+
+type ForkWorkflowSpec struct {
+    OriginalWorkflowID string // Required: The UUID of the original workflow to fork from
+    ForkedWorkflowID   string // Optional: Custom workflow ID for the forked workflow (auto-generated if empty)
+    StartStep          uint   // Optional: Step to start the forked workflow from (default: 0)
+}
+```
+
+The `ApplicationVersion`, `QueueName`, and `QueuePartitionKey` settings apply to every forked workflow in the batch.
+
+**Example:**
+
+```go
+handles, err := dbos.ForkWorkflows[any](ctx, dbos.ForkWorkflowsInput{
+    Workflows: []dbos.ForkWorkflowSpec{
+        {OriginalWorkflowID: "wf-1", StartStep: 2},
+        {OriginalWorkflowID: "wf-2"},
+    },
+    QueueName: "fork_queue",
+})
+```
+
 ### SetWorkflowDelay
 
 ```go
@@ -827,6 +879,7 @@ type WorkflowStatus struct {
     Priority           int                `json:"priority"`            // Execution priority (lower numbers have higher priority)
     DelayUntil         time.Time          `json:"delay_until"`         // Time before which a DELAYED workflow should not be dequeued
     Attributes         map[string]any     `json:"attributes"`          // Custom key-value attributes attached to the workflow
+    ScheduleName       string             `json:"schedule_name"`       // Name of the schedule that enqueued this workflow (if any)
 }
 ```
 
@@ -943,6 +996,9 @@ func WithAutomaticBackfill(enabled bool) CreateScheduleOption
 
 Enable automatic backfill of missed ticks when the schedule is reloaded after downtime (or when a paused schedule is resumed).
 
+Missed ticks are computed with the schedule's **current** cron expression, over the window from the last fire to now.
+If you change a schedule's cron expression (e.g. with [`ApplySchedules`](#applyschedules)) while it is not running, the backfill generates one execution per tick of the *new* expression across that entire window—including times the old expression would never have matched.
+
 #### WithCronTimezone
 
 ```go
@@ -986,11 +1042,16 @@ err := dbos.CreateSchedule(ctx, myPeriodicTask, dbos.CreateScheduleRequest{
 func ApplySchedules(ctx DBOSContext, schedules []ApplySchedulesRequest) error
 ```
 
-Atomically create or replace a list of schedules in a single transaction.
-For each entry, any existing schedule with the same name is deleted before the new schedule is inserted.
+Atomically create or update a list of schedules in a single transaction.
+Existing schedules are upserted by name: all definition fields (workflow name and class, cron expression, context, timezone, queue, and backfill flag) are replaced with the new entry's values, while the schedule's ID, status, and last-fired time are preserved.
 Useful for defining a fixed set of static schedules on application start.
 
 `ApplySchedules` cannot be called from within a workflow.
+
+:::warning
+Because every definition field is replaced, omitting an optional field on re-apply clears it.
+In particular, a schedule previously routed to a named queue reverts to the internal queue if the new entry does not set `QueueName`.
+:::
 
 ```go
 type ApplySchedulesRequest struct {

--- a/docs/golang/reference/workflows-steps.md
+++ b/docs/golang/reference/workflows-steps.md
@@ -18,6 +18,10 @@ Workflow functions must be compatible with the following signature:
 type Workflow[P any, R any] func(ctx DBOSContext, input P) (R, error)
 ```
 
+Returned errors are persisted with [gob](https://pkg.go.dev/encoding/gob), preserving their concrete type when read back (e.g., from a workflow handle in another process).
+An error that cannot be gob-encoded—including those created by `errors.New` or `fmt.Errorf`, whose fields are unexported—is stored as its message string only, so `errors.Is` and `errors.As` will not match it after a database round-trip.
+To preserve a custom error type, give it exported fields and register it with [`gob.Register`](https://pkg.go.dev/encoding/gob#Register).
+
 **Parameters:**
 - **ctx**: The DBOSContext.
 - **fn**: The workflow function to register.

--- a/docs/golang/tutorials/scheduled-workflows.md
+++ b/docs/golang/tutorials/scheduled-workflows.md
@@ -5,7 +5,7 @@ title: Scheduling Workflows
 
 You can schedule DBOS [workflows](./workflow-tutorial.md) to run on a cron schedule.
 Schedules are stored in the database and can be created, paused, resumed, and deleted at runtime.
-Each time a scheduled fires, its workflow is executed by exactly one worker process.
+Each time a schedule fires, its workflow is executed by exactly one worker process.
 
 To schedule a workflow, first define a workflow whose input is a [`ScheduledWorkflowInput`](../reference/methods.md#scheduledworkflowinput).
 This struct carries the cron tick time (`ScheduledTime`) and a user-defined `Context` value attached to the schedule:
@@ -49,6 +49,10 @@ err := dbos.ApplySchedules(dbosContext, []dbos.ApplySchedulesRequest{
     },
 })
 ```
+
+When `ApplySchedules` updates an existing schedule, it replaces the entire definition with the new entry, so any optional field left unset is cleared.
+For example, if a schedule was routed to a named queue and you re-apply it without setting `QueueName`, it reverts to the internal queue.
+The schedule's status and last-fired time are preserved.
 
 To learn more about crontab syntax, see [this guide](https://docs.gitlab.com/ee/topics/cron/) or [this crontab editor](https://crontab.guru/).
 DBOS Go uses [robfig/cron](https://pkg.go.dev/github.com/robfig/cron/v3) to parse cron schedules, with seconds as an optional first field.
@@ -130,6 +134,10 @@ ids, err := dbos.BackfillSchedule(dbosContext, "my-task-schedule", start, end)
 
 Alternatively, pass [`WithAutomaticBackfill(true)`](../reference/methods.md#withautomaticbackfill) when creating a schedule so that missed executions are automatically backfilled whenever your application starts or a paused schedule is resumed.
 
+Backfills (manual or automatic) compute missed executions using the schedule's **current** cron expression.
+If you update a schedule's cron expression and then backfill, the backfill generates one execution per tick of the new expression over the requested window—including times the old expression would never have matched.
+For example, changing a daily schedule to an hourly one and then backfilling yesterday enqueues 24 executions, not 1.
+
 You can also immediately trigger a schedule using [`TriggerSchedule`](../reference/methods.md#triggerschedule):
 
 ```go
@@ -176,5 +184,11 @@ err = client.CreateSchedule(dbos.ClientScheduleInput{
 
 Under the hood, DBOS constructs an [idempotency key](./workflow-tutorial.md#workflow-ids-and-idempotency) for each scheduled workflow execution.
 The key is the concatenation of `sched-`, the schedule name, and the scheduled time (RFC3339), ensuring each scheduled invocation occurs exactly once even when multiple application instances share the same schedule.
+
+When a schedule fires, its workflow is enqueued by name rather than invoked directly, so the process hosting the schedule does not need to have the workflow registered.
+Name resolution happens at dequeue time on a worker that has the function, letting any process connected to the system database drive schedules for workflows owned by other processes or languages.
+Scheduled workflows always run against the latest registered application version, so a stale executor does not pick them up after a new deploy.
+
+You can list the workflows started by a schedule by passing [`WithFilterScheduleName`](../reference/methods.md#withfilterschedulename) to [`ListWorkflows`](../reference/methods.md#listworkflows).
 
 For the full API reference, see [Workflow Schedules](../reference/methods.md#workflow-schedules).

--- a/docs/golang/tutorials/workflow-tutorial.md
+++ b/docs/golang/tutorials/workflow-tutorial.md
@@ -118,6 +118,18 @@ Instead, you should do all database operations in non-deterministic operations i
 
 :::warning
 Go's goroutine scheduler and `select` operation are non-deterministic. You should use them only inside steps, or use the durable [`Go`](#concurrent-steps) and [`Select`](#selecting-the-first-result) functions instead.
+
+Go's map iteration order is also random: each iteration over the same map may visit keys in a different order.
+Don't call steps or start workflows while ranging over a map—on recovery, the iteration order changes and operations replay in a different order, breaking determinism.
+Sort the keys first and iterate over the sorted slice instead:
+
+```go
+keys := slices.Sorted(maps.Keys(m))
+for _, k := range keys {
+    handle, err := dbos.RunWorkflow(ctx, processItem, m[k])
+    // ...
+}
+```
 :::
 
 For example, **don't do this**:

--- a/docs/java/reference/methods.md
+++ b/docs/java/reference/methods.md
@@ -809,7 +809,7 @@ void applySchedules(WorkflowSchedule... schedules)
 void applySchedules(List<WorkflowSchedule> schedules)
 ```
 
-Atomically create or replace a set of schedules in one transaction. Each named schedule is deleted (if it exists) and re-created. This is the recommended way to declare schedules at application startup — call it once after `dbos.launch()` and it will always reflect your current schedule definitions.
+Atomically create or update a set of schedules in one transaction. Existing schedules are upserted by name: all definition fields are replaced with the new declaration's values (so any optional setting left unset is cleared, e.g. an omitted queue name reverts the schedule to the default scheduler queue), while the schedule's status and last-fired time are preserved. This is the recommended way to declare schedules at application startup — call it once after `dbos.launch()` and it will always reflect your current schedule definitions.
 
 ### createSchedule
 

--- a/docs/java/tutorials/scheduled-workflows.md
+++ b/docs/java/tutorials/scheduled-workflows.md
@@ -36,6 +36,10 @@ public void everyMinute(Instant scheduled, Object context) {
 
 `applySchedules` is idempotent: re-running it on every startup always results in the declared set of schedules, with no duplicates.
 
+When `applySchedules` updates an existing schedule, it replaces the entire definition with the new declaration, so any optional setting left unset is cleared.
+For example, if a schedule was routed to a named queue and you re-apply it without `withQueueName(...)`, it reverts to the default scheduler queue.
+The schedule's status and last-fired time are preserved.
+
 ### WorkflowSchedule Parameters
 
 ```java
@@ -95,6 +99,10 @@ List<WorkflowHandle<Object, Exception>> handles =
 ```
 
 DBOS uses the same deterministic workflow IDs as the live scheduler, so executions that already ran are skipped.
+
+Backfills (manual or automatic) compute missed executions using the schedule's **current** cron expression.
+If you update a schedule's cron expression and then backfill, the backfill generates one execution per tick of the new expression over the requested window—including times the old expression would never have matched.
+For example, changing a daily schedule to an hourly one and then backfilling yesterday enqueues 24 executions, not 1.
 
 You can also enable **automatic backfill** on a schedule so DBOS does this for you on every startup:
 

--- a/docs/python/reference/contexts.md
+++ b/docs/python/reference/contexts.md
@@ -1360,6 +1360,8 @@ Atomically apply a set of schedules.
 Useful for declaratively defining all your static schedules in one place.
 May not be called from within a workflow.
 
+Existing schedules are upserted by name: all definition fields are replaced with the new entry's values (so any optional field left unset is cleared, e.g. an omitted `queue_name` reverts the schedule to the internal queue), while the schedule's status and last-fired time are preserved.
+
 **Example:**
 
 ```python

--- a/docs/python/tutorials/scheduled-workflows.md
+++ b/docs/python/tutorials/scheduled-workflows.md
@@ -50,6 +50,10 @@ DBOS.apply_schedules([
 ])
 ```
 
+When `DBOS.apply_schedules` updates an existing schedule, it replaces the entire definition with the new entry, so any optional field left unset is cleared.
+For example, if a schedule was routed to a named queue and you re-apply it without setting `queue_name`, it reverts to the internal queue.
+The schedule's status and last-fired time are preserved.
+
 To learn more about crontab syntax, see [this guide](https://docs.gitlab.com/ee/topics/cron/) or [this crontab editor](https://crontab.guru/).
 DBOS uses [croniter](https://pypi.org/project/croniter/) to parse cron schedules, using seconds as an optional first field ([`second_at_beginning=True`](https://pypi.org/project/croniter/#about-second-repeats)).
 Valid cron schedules contain 5 or 6 items, separated by spaces:
@@ -139,6 +143,10 @@ DBOS.backfill_schedule(
 ```
 
 Alternatively, you can set `automatic_backfill=True` when creating a schedule so that missed executions are automatically backfilled whenever your application starts or a paused schedule is resumed.
+
+Backfills (manual or automatic) compute missed executions using the schedule's **current** cron expression.
+If you update a schedule's cron expression and then backfill, the backfill generates one execution per tick of the new expression over the requested window—including times the old expression would never have matched.
+For example, changing a daily schedule to an hourly one and then backfilling yesterday enqueues 24 executions, not 1.
 
 You can also immediately trigger a schedule using [`DBOS.trigger_schedule`](../reference/contexts.md#trigger_schedule):
 

--- a/docs/typescript/reference/methods.md
+++ b/docs/typescript/reference/methods.md
@@ -800,6 +800,8 @@ Atomically apply a set of schedules.
 Creates or updates each schedule in the list.
 May not be called from within a workflow.
 
+Existing schedules are upserted by name: all definition fields are replaced with the new entry's values (so any optional field left unset is cleared, e.g. an omitted `queueName` reverts the schedule to the internal queue), while the schedule's status and last-fired time are preserved.
+
 **Example:**
 
 ```typescript

--- a/docs/typescript/tutorials/scheduled-workflows.md
+++ b/docs/typescript/tutorials/scheduled-workflows.md
@@ -47,6 +47,10 @@ await DBOS.applySchedules([
 ]);
 ```
 
+When `DBOS.applySchedules` updates an existing schedule, it replaces the entire definition with the new entry, so any optional field left unset is cleared.
+For example, if a schedule was routed to a named queue and you re-apply it without setting `queueName`, it reverts to the internal queue.
+The schedule's status and last-fired time are preserved.
+
 To learn more about crontab syntax, see [this guide](https://docs.gitlab.com/ee/topics/cron/) or [this crontab editor](https://crontab.guru/).
 Valid cron schedules contain 5 or 6 items, separated by spaces:
 
@@ -132,6 +136,10 @@ await DBOS.backfillSchedule(
 ```
 
 Alternatively, you can set `automaticBackfill: true` when creating a schedule so that missed executions are automatically backfilled whenever your application starts or a paused schedule is resumed.
+
+Backfills (manual or automatic) compute missed executions using the schedule's **current** cron expression.
+If you update a schedule's cron expression and then backfill, the backfill generates one execution per tick of the new expression over the requested window—including times the old expression would never have matched.
+For example, changing a daily schedule to an hourly one and then backfilling yesterday enqueues 24 executions, not 1.
 
 You can also immediately trigger a schedule using [`DBOS.triggerSchedule`](../reference/methods.md#dbostriggerschedule):
 


### PR DESCRIPTION
Also:
* Warn users about schedule backfill behavior on updated specs
* Warn users about risk of clearing a custom queue name when updating a schedule
* Warn users against iterating on Go maps to launch steps