### PR TITLE
Stop a blocked Matomo tracker from crashing the page

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -99,6 +99,21 @@ const config = {
     locales: ['en'],
   },
 
+  // docusaurus-plugin-matomo's route tracker pushes to the bare global _paq on
+  // every navigation, but the snippet that defines it is a separate inline
+  // script. Content blockers recognize and strip that snippet, leaving the
+  // tracker to throw "_paq is not defined" into React, which the error boundary
+  // renders as "This page crashed". Seed the queue here so a blocked tracker
+  // costs us analytics instead of the page. Only production builds load either
+  // half, so this is inert in `npm start`.
+  headTags: [
+    {
+      tagName: 'script',
+      attributes: {},
+      innerHTML: 'window._paq = window._paq || [];',
+    },
+  ],
+
   plugins: [
     CopyMarkdownPlugin,
     pluginLlmsTxt,


### PR DESCRIPTION
Navigating the built site can replace the page with Docusaurus's **"This page crashed — `_paq is not defined`"** error boundary. The cause is in `docusaurus-plugin-matomo`, not in our content.

## What happens

The plugin splits its integration in two:

- an inline `<head>` snippet that defines the queue: `var _paq = window._paq = window._paq || []`
- a client module ([`track.js`](https://github.com/karser/docusaurus-plugin-matomo/blob/master/src/track.js)) whose `onRouteUpdate` pushes to a **bare, unguarded** `_paq` on every navigation

If the defining snippet never runs, each navigation throws `ReferenceError: _paq is not defined` inside React, and the error boundary swallows the page.

Content blockers cause exactly that. The asymmetry is worth noting: blocking only the `matomo.js` *network request* is harmless — the array exists and pushes accumulate unsent. It's blockers that match and strip the **inline snippet** that break us, because that removes the definition while leaving the tracker running. Any visitor with such a blocker gets a crashed page, not just a missing analytics beacon.

## The fix

Seed `window._paq` in `headTags`, so the bare reference always resolves and a blocked tracker costs analytics rather than the page.

This is deliberately a guard rather than a patch to the dependency — it needs no `patch-package` and survives a plugin upgrade.

## Scope

Both halves of the plugin are gated on `NODE_ENV=production`, so this is inert under `npm start` and only matters in a real build.

## Verification

`npm run build` succeeds, and both scripts land in the built `<head>`: the plugin's snippet, then ours. Confirmed a bare `_paq` resolves against a `window._paq` assignment. The two broken anchors the build reports are pre-existing, in the Go reference docs, and untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)