### PR TITLE
Stop a blocked PostHog tracker from crashing the page

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -99,18 +99,28 @@ const config = {
     locales: ['en'],
   },
 
-  // docusaurus-plugin-matomo's route tracker pushes to the bare global _paq on
-  // every navigation, but the snippet that defines it is a separate inline
-  // script. Content blockers recognize and strip that snippet, leaving the
-  // tracker to throw "_paq is not defined" into React, which the error boundary
-  // renders as "This page crashed". Seed the queue here so a blocked tracker
-  // costs us analytics instead of the page. Only production builds load either
-  // half, so this is inert in `npm start`.
+  // Both analytics plugins split themselves the same way: an inline head
+  // snippet defines the global, and a separate client module dereferences it on
+  // every navigation without a guard. Content blockers recognize and strip the
+  // snippets, so the trackers throw into React and the error boundary renders
+  // "This page crashed" -- "_paq is not defined" for Matomo, "Cannot read
+  // properties of undefined (reading 'capture')" for PostHog. Seed both globals
+  // so a blocked tracker costs us analytics instead of the page.
+  //
+  // The shapes here are what each vendor snippet expects to find, so seeding is
+  // invisible when the snippet does run: it augments the same array in place.
+  // PostHog additionally needs a callable `capture`, which its snippet then
+  // replaces with the real queueing stub. Only production builds load either
+  // plugin, so all of this is inert in `npm start`.
   headTags: [
     {
       tagName: 'script',
       attributes: {},
-      innerHTML: 'window._paq = window._paq || [];',
+      innerHTML: [
+        'window._paq = window._paq || [];',
+        'window.posthog = window.posthog || [];',
+        'if (!window.posthog.capture) { window.posthog.capture = function () {}; }',
+      ].join('\n'),
     },
   ],
 


### PR DESCRIPTION
Follow-up to #606. Same defect, other analytics plugin — fixing Matomo alone just exposed this one behind it.

## What happens

`posthog-docusaurus` splits itself exactly like the Matomo plugin did:

- an inline `<head>` snippet that defines `window.posthog`
- a client module ([`posthog.js`](https://github.com/PostHog/posthog-docusaurus/blob/main/src/posthog.js)) whose `onRouteUpdate` calls `window.posthog.capture('$pageview')` with **no guard**

When a content blocker strips the snippet, every navigation throws `TypeError: Cannot read properties of undefined (reading 'capture')`, and Docusaurus's error boundary replaces the page with "This page crashed".

## The fix

Seed both globals in the same `headTags` script.

The shapes matter: PostHog's snippet expects to find an array and augments it in place, so seeding an array is invisible when the snippet does run. The placeholder `capture` is likewise replaced by PostHog's real queueing stub — I verified a `$pageview` still lands on the queue after the vendor snippet initializes over the seed. Blocked, `capture` degrades to a no-op rather than a `TypeError`.

## No third instance

I swept every installed plugin's client modules for the same pattern. Only these two had it: `theme-classic`'s nprogress imports its dependency rather than reading a global, and the hubspot plugin registers no client module.

## Scope

Both plugins are gated on `NODE_ENV=production`, so this is inert under `npm start` and only matters in a real build.

Developers hitting this locally can also just allowlist localhost in their blocker — but visitors to the deployed site can't, which is what this fixes.

## Verification

`npm run build` succeeds; the seed and the vendor snippet both land in the built `<head>`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)