### PR TITLE
Document the dbosctl sysdb commands: migrate, reset, and rename-application

### DIFF
--- a/docs/explanations/sharing-a-system-database.md
+++ b/docs/explanations/sharing-a-system-database.md
@@ -94,14 +94,19 @@ To ensure no rows are unowned, always pass an application name to your clients w
 Before adding a second application to a system database, explicitly transfer ownership of any unowned rows to the first application:
 
 ```shell
-dbos rename-application --to my-app --adopt-unclaimed-rows
+dbosctl sysdb rename-application --to my-app --adopt-unclaimed-rows
 ```
 
 ## Renaming an Application
 
 Because ownership is recorded under the application's name, renaming an application requires transferring ownership of its rows.
-To rename an application, first stop it, then run `dbos rename-application` ([Python](../python/reference/cli.md#dbos-rename-application), [TypeScript](../typescript/reference/cli.md#npx-dbos-rename-application), [Go](../golang/reference/methods.md#renameapplication)), then restart it under its new name:
+To rename an application, first stop it, then run [`dbosctl sysdb rename-application`](../production/dbosctl.md#dbosctl-sysdb-rename-application), then restart it under its new name:
 
 ```shell
-dbos rename-application --from old-name --to new-name
+dbosctl sysdb rename-application --from old-name --to new-name
 ```
+
+[`dbosctl`](../production/dbosctl.md) is the recommended way to run this: a system database shared by applications in different languages is not any one language's to manage, and `dbosctl` is a single binary that works against all of them.
+It takes the database URL from `-D`/`--db-url` or `$DBOS_SYSTEM_DATABASE_URL` rather than from an application's configuration.
+
+Each SDK also ships the same command for its own language, reading the system database URL from that language's configuration: [Python](../python/reference/cli.md#dbos-rename-application), [TypeScript](../typescript/reference/cli.md#npx-dbos-rename-application), and, in Go, [`RenameApplication`](../golang/reference/methods.md#renameapplication).

--- a/docs/explanations/sharing-a-system-database.md
+++ b/docs/explanations/sharing-a-system-database.md
@@ -103,10 +103,5 @@ Because ownership is recorded under the application's name, renaming an applicat
 To rename an application, first stop it, then run [`dbosctl sysdb rename-application`](../production/dbosctl.md#dbosctl-sysdb-rename-application), then restart it under its new name:
 
 ```shell
-dbosctl sysdb rename-application --from old-name --to new-name
+dbosctl sysdb rename-application --from old-name --to new-name --db-url <Postgres connection URL>
 ```
-
-[`dbosctl`](../production/dbosctl.md) is the recommended way to run this: a system database shared by applications in different languages is not any one language's to manage, and `dbosctl` is a single binary that works against all of them.
-It takes the database URL from `-D`/`--db-url` or `$DBOS_SYSTEM_DATABASE_URL` rather than from an application's configuration.
-
-Each SDK also ships the same command for its own language, reading the system database URL from that language's configuration: [Python](../python/reference/cli.md#dbos-rename-application), [TypeScript](../typescript/reference/cli.md#npx-dbos-rename-application), and, in Go, [`RenameApplication`](../golang/reference/methods.md#renameapplication).

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -101,7 +101,7 @@ You can connect a DBOS application to its system database through a connection p
 DBOS creates tables for its internal state in its [system database](./explanations/system-tables.md).
 By default, a DBOS application automatically creates these on startup.
 However, in production environments, a DBOS application may not run with sufficient privilege to create databases or tables.
-In that case, the [`dbosctl migrate`](./production/dbosctl.md#dbosctl-migrate) command can be run with a privileged user to create all DBOS system tables.
+In that case, the [`dbosctl sysdb migrate`](./production/dbosctl.md#dbosctl-sysdb-migrate) command can be run with a privileged user to create all DBOS system tables.
 Then, a DBOS application can run without privilege (requiring only access to the system database).
 
 ### What database privileges does DBOS need, and how do I grant them manually?
@@ -127,7 +127,7 @@ ALTER DEFAULT PRIVILEGES IN SCHEMA "dbos" GRANT ALL ON SEQUENCES TO "your_app_ro
 ALTER DEFAULT PRIVILEGES IN SCHEMA "dbos" GRANT EXECUTE ON FUNCTIONS TO "your_app_role";
 ```
 
-The [`dbosctl migrate`](./production/dbosctl.md#dbosctl-migrate) command does this automatically if you supply an application role with `-r`/`--app-role`.
+The [`dbosctl sysdb migrate`](./production/dbosctl.md#dbosctl-sysdb-migrate) command does this automatically if you supply an application role with `-r`/`--app-role`.
 
 ### How does DBOS scale?
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -101,7 +101,7 @@ You can connect a DBOS application to its system database through a connection p
 DBOS creates tables for its internal state in its [system database](./explanations/system-tables.md).
 By default, a DBOS application automatically creates these on startup.
 However, in production environments, a DBOS application may not run with sufficient privilege to create databases or tables.
-In that case, the [`dbos migrate`](./python/reference/cli.md#dbos-migrate) command in Python, the [`dbos migrate`](./golang/reference/cli.md) in Go, or the [`dbos schema`](./typescript/reference/cli.md#npx-dbos-schema) command in TypeScript can be run with a privileged user to create all DBOS database tables.
+In that case, the [`dbosctl migrate`](./production/dbosctl.md#dbosctl-migrate) command can be run with a privileged user to create all DBOS system tables.
 Then, a DBOS application can run without privilege (requiring only access to the system database).
 
 ### What database privileges does DBOS need, and how do I grant them manually?
@@ -127,7 +127,7 @@ ALTER DEFAULT PRIVILEGES IN SCHEMA "dbos" GRANT ALL ON SEQUENCES TO "your_app_ro
 ALTER DEFAULT PRIVILEGES IN SCHEMA "dbos" GRANT EXECUTE ON FUNCTIONS TO "your_app_role";
 ```
 
-The [`dbos migrate`](./python/reference/cli.md#dbos-migrate) command in Python, the [`dbos migrate`](./golang/reference/cli.md) in Go, and the [`dbos schema`](./typescript/reference/cli.md#npx-dbos-schema) command in TypeScript do this automatically if you supply an application role.
+The [`dbosctl migrate`](./production/dbosctl.md#dbosctl-migrate) command does this automatically if you supply an application role with `-r`/`--app-role`.
 
 ### How does DBOS scale?
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -85,7 +85,11 @@ If you enqueue a workflow with the ID of a workflow that already exists, it's a 
 
 ### How can I reset all my DBOS state during development?
 
-You can reset your DBOS system database and all internal DBOS state with the `dbos reset` command ([Python](./python/reference/cli.md#dbos-reset), [TypeScript](./typescript/reference/cli.md#npx-dbos-reset), [Go](./golang/reference/cli.md)).
+You can reset your DBOS system database and all internal DBOS state with the [`dbosctl sysdb reset`](./production/dbosctl.md#dbosctl-sysdb-reset) command.
+It empties the DBOS tables and leaves the schema migrated, so nothing has to provision the database again between runs, and it works the same way whatever language your application is written in.
+Pass `--app` to reset just one application's state in a [shared system database](./explanations/sharing-a-system-database.md), or `--drop-database` to drop the database outright.
+
+Each SDK also ships a `dbos reset` command for its own language, which drops the database ([Python](./python/reference/cli.md#dbos-reset), [TypeScript](./typescript/reference/cli.md#npx-dbos-reset), [Go](./golang/reference/cli.md)).
 
 ### How can I reduce the number of Postgres connections DBOS uses?
 

--- a/docs/production/checklist.md
+++ b/docs/production/checklist.md
@@ -21,9 +21,9 @@ Here are some recommendations for configuring a Postgres database to best work w
 **Manage the DBOS schema** - DBOS creates tables for its internal state in its [system database](../explanations/system-tables.md).
 By default, a DBOS application automatically creates these on startup.
 However, in production environments, a DBOS application may not run with sufficient privilege to create databases or tables.
-In that case, the [`dbosctl migrate`](./dbosctl.md#dbosctl-migrate) command can be run with a privileged user to create all DBOS system tables or migrate them to the latest version.
+In that case, the [`dbosctl sysdb migrate`](./dbosctl.md#dbosctl-sysdb-migrate) command can be run with a privileged user to create all DBOS system tables or migrate them to the latest version.
 Then, a DBOS application can run with lower privilege (requiring only access to the DBOS tables in the system database).
-If your database is managed by a DBA, `dbosctl migrate` can also print the SQL for them to apply instead of running it itself.
+If your database is managed by a DBA, `dbosctl sysdb migrate` can also print the SQL for them to apply instead of running it itself.
 
 ## Scalability
 

--- a/docs/production/checklist.md
+++ b/docs/production/checklist.md
@@ -21,8 +21,9 @@ Here are some recommendations for configuring a Postgres database to best work w
 **Manage the DBOS schema** - DBOS creates tables for its internal state in its [system database](../explanations/system-tables.md).
 By default, a DBOS application automatically creates these on startup.
 However, in production environments, a DBOS application may not run with sufficient privilege to create databases or tables.
-In that case, the [`dbos migrate`](../python/reference/cli.md#dbos-migrate) command in Python, the [`dbos migrate`](../golang/reference/cli.md) in Go, or the [`dbos schema`](../typescript/reference/cli.md#npx-dbos-schema) command in TypeScript can be run with a privileged user to create all DBOS database tables or migrate them to the latest version.
+In that case, the [`dbosctl migrate`](./dbosctl.md#dbosctl-migrate) command can be run with a privileged user to create all DBOS system tables or migrate them to the latest version.
 Then, a DBOS application can run with lower privilege (requiring only access to the DBOS tables in the system database).
+If your database is managed by a DBA, `dbosctl migrate` can also print the SQL for them to apply instead of running it itself.
 
 ## Scalability
 

--- a/docs/production/dbosctl.md
+++ b/docs/production/dbosctl.md
@@ -562,21 +562,74 @@ Lists the permissions that can be granted to an API key or a role.
 ### `dbosctl migrate`
 
 **Description:**
-Creates or upgrades the DBOS [system database](../explanations/system-tables.md), applying every migration its schema is missing and creating the database and the schema if they do not exist yet.
+Creates or upgrades the DBOS [system database](../explanations/system-tables.md).
+By default, a DBOS application automatically creates these on startup.
+However, in production environments, a DBOS application may not run with sufficient privilege to create databases or tables.
+In that case, the `migrate` command can be run with a privileged user to create all DBOS database tables.
 
-By default a DBOS application creates and upgrades these tables itself on startup.
-In production it often cannot: the role it runs as has no privilege to create databases or tables.
-Run `migrate` with a privileged role first, and the application can then run with access to the DBOS schema alone — grant it with `-r/--app-role`, and configure the application not to run migrations itself, so that it verifies the schema at launch rather than altering it.
+After creating the DBOS database tables with this command, a DBOS application can run with minimum permissions, requiring only access to the DBOS schema in the application and system databases.
+Use the `-r/--app-role` flag to grant a role access to that schema.
 
-The migrations are built into the binary, and the system schema is shared by every DBOS SDK, so provisioning a database does not mean picking an SDK and installing its toolchain.
-This is the only `dbosctl` command that opens a database: it takes a database URL rather than a profile, and accepts none of the [common flags](#common-flags).
+The migrations are built into the `dbosctl` binary, and the system schema is shared by every DBOS SDK, so provisioning a database does not require picking an SDK and installing its toolchain.
+The `migrate` command includes an  flag to grant the specified role read/write access to the DBOS schema.
 
-It is safe to re-run. Migrations already recorded are skipped, so a database that is up to date is left alone.
+Note, this `dbosctl` command connects to your database instead of Conductor.
+It takes a database URL rather than a profile, and accepts none of the [common flags](#common-flags).
 
 ```shell
 dbosctl migrate -D postgres://user:password@host:5432/dbos_sys
 DBOS_SYSTEM_DATABASE_URL=postgres://user:password@host:5432/dbos_sys dbosctl migrate
 ```
+
+`migrate` is safe to re-run. Migrations already recorded are skipped, so a database that is up to date is left alone.
+
+:::info SDK migration config settings
+After running `dbosctl migrate`, configure your application not to alter the system schema on startup where that option exists:
+
+<Tabs groupId="language" queryString="language">
+<TabItem value="python" label="Python">
+
+```python
+config: DBOSConfig = {
+  "name": "my-app",
+  "system_database_url": os.environ["DBOS_SYSTEM_DATABASE_URL"],
+  "run_migrations": False,
+}
+```
+
+</TabItem>
+<TabItem value="typescript" label="TypeScript">
+
+```typescript
+await DBOS.launch({
+  name: "my-app",
+  systemDatabaseUrl: process.env.DBOS_SYSTEM_DATABASE_URL,
+  runMigrations: false,
+});
+```
+
+</TabItem>
+<TabItem value="golang" label="Go">
+
+DBOS Go does not expose a `runMigrations` toggle. `NewContext` always checks the DBOS schema and attempts to apply pending migrations. 
+
+If you run your DBOS Go application without DDL permissions against a missing or out-of-data system database,
+it will fail to launch due to denied DDL permissions.
+The application will launch correctly if the database exists and is up-to-date (which the `migrate` command ensures).
+
+</TabItem>
+<TabItem value="java" label="Java">
+
+```java
+DBOSConfig config = DBOSConfig.defaults("my-app")
+  .withDatabaseUrl(System.getenv("DBOS_SYSTEM_JDBC_URL"))
+  .withMigrate(false);
+```
+
+</TabItem>
+</Tabs>
+
+:::
 
 **Arguments:**
 - `-D, --db-url <url>`: The system database URL. Overrides `$DBOS_SYSTEM_DATABASE_URL`. Postgres and CockroachDB only — a SQLite system database is migrated by the application process that opens it.

--- a/docs/production/dbosctl.md
+++ b/docs/production/dbosctl.md
@@ -732,10 +732,20 @@ Prompts for confirmation when run interactively.
 - `-t, --to <name>`: The application that ends up owning the rows. Required.
 - `--adopt-unclaimed-rows`: Also transfer rows no application owns (`application_name` is null).
 - `--batch-size <int>`: Completed workflows and steps transferred per transaction. Defaults to 10000.
-- `--force`: Skip the confirmation prompt. Required when running non-interactively.
+- `--force`: Skip the confirmation prompt and the `--to` name checks. Required when running non-interactively.
 - `-o, --output <format>`: Output format for the row counts — `table` (default) or `json`.
 
 Rows no application owns predate system-database sharing, so claiming them is a decision rather than a default: naming neither source is an error rather than a rename that reports moving nothing.
+
+`--to` is looked at before anything moves.
+A name that is only whitespace is refused outright — no application can be configured with it, so the rename would move a whole history somewhere nothing will look for it again.
+Two others are reported above the confirmation prompt and asked about rather than refused:
+
+- A name outside `^[a-z0-9-_]{3,30}$`. DBOS Transact places no limits on an application name, but DBOS Conductor and Cloud do: a name that does not match cannot be registered or used with either.
+- A name that already owns rows in the schema. Merging two applications is a real thing to want, and it is what `--to` alone with `--adopt-unclaimed-rows` does on purpose.
+
+Each is also exactly what the corresponding mistake looks like — a stray capital or space, and a `--to` naming the wrong existing application — and nothing here can tell the two apart, so the answer to the prompt decides them.
+`--force` skips that prompt and both questions with it, including the query that asks the database whether the name is already taken.
 
 Queues, schedules, versions, and in-flight workflows move in one transaction — a half-owned application would dequeue work whose version row it can no longer see.
 Completed workflows and their steps are unbounded, so they move in batches of `--batch-size` keys, and re-running an interrupted rename picks up where it stopped rather than starting over.

--- a/docs/production/dbosctl.md
+++ b/docs/production/dbosctl.md
@@ -260,6 +260,7 @@ Registers an application with Conductor. The name must match the application nam
 
 **Arguments:**
 - `<name>`: The application's name.
+- `--private-mode`: Register the application in private mode, so it does not send workflow payload data — inputs, outputs, and events — to Conductor. Omit the flag to take Conductor's default; it can be changed later with [`dbosctl app update`](#dbosctl-app-update).
 
 ---
 
@@ -274,7 +275,7 @@ Updates an application's tuning settings. Only the flags you pass are changed.
 - `--global-timeout-ms <int>`: Global workflow timeout, in milliseconds.
 - `--gc-rows-threshold <int>`: Workflow rows kept before garbage collection. See [Workflow Retention Policies](./retention.md).
 - `--gc-time-threshold-ms <int>`: Age, in milliseconds, before a workflow is garbage-collected.
-- `--private-mode`: Restrict the application to members of the organization.
+- `--private-mode`: Whether the application is in private mode, in which it does not send workflow payload data — inputs, outputs, and events — to Conductor. Pass `--private-mode=false` to turn it back off.
 
 ---
 

--- a/docs/production/dbosctl.md
+++ b/docs/production/dbosctl.md
@@ -5,7 +5,7 @@ title: dbosctl CLI Reference
 
 `dbosctl` is a command-line client for the [Conductor API](./conductor-api.md). It manages workflows, queues, schedules, applications, and API keys against DBOS-managed Conductor or a [self-hosted Conductor](./hosting-conductor.md), with the target selected by a named **profile**.
 
-[`dbosctl migrate`](#dbosctl-migrate) is the exception: it opens a Postgres [system database](../explanations/system-tables.md) directly to create or upgrade the DBOS schema, so it takes a database URL rather than a profile.
+The [`dbosctl sysdb`](#system-database-commands) commands are the exception: they open a Postgres [system database](../explanations/system-tables.md) directly — to migrate it, empty it, or re-own its rows after an application is renamed — so they take a database URL rather than a profile.
 
 ## Installation
 
@@ -106,7 +106,7 @@ Each setting is resolved **flag → environment variable → profile**, so a fla
 | Organization | `--org` | `DBOS_ORG` |
 | Application | `-a`, `--app` | `DBOS_APP` |
 | Bearer token | — | `DBOS_TOKEN` |
-| System database ([`migrate`](#dbosctl-migrate) only) | `-D`, `--db-url` | `DBOS_SYSTEM_DATABASE_URL` |
+| System database ([`sysdb`](#system-database-commands) only) | `-D`, `--db-url` | `DBOS_SYSTEM_DATABASE_URL` |
 | Output format | `-o`, `--output` | — |
 
 Flags are scoped to the command that uses them, so pass them **after** the command name (`dbosctl app list --org acme`). Each command's `--help` lists only the flags it honors.
@@ -121,7 +121,7 @@ These flags are accepted by most commands and are not repeated in the reference 
 - `-a, --app <name>`: Application name, for application-scoped commands. Overrides `$DBOS_APP` and the profile.
 - `-o, --output <format>`: Output format — `table` (default), `json`, or `ids`.
 
-[`dbosctl migrate`](#dbosctl-migrate) accepts none of them. It does not talk to Conductor, so there is no profile, organization, or application to name, and what it writes is progress text or SQL rather than a formatted result.
+The [`dbosctl sysdb`](#system-database-commands) commands accept none of them except `-o`. They do not talk to Conductor, so there is no profile, organization, or application to name. `sysdb reset` and `sysdb rename-application` print row counts, so they honor `-o` like every other command that prints data — `table` or `json`, but not `ids`. (`sysdb reset` has an `--app` flag of its own, read from the command line only.)
 
 ## Output
 
@@ -159,8 +159,8 @@ Conductor answers some commands itself and forwards the rest to your application
 | | Commands |
 | --- | --- |
 | Forwarded to your application | All `workflow`, `queue`, and `schedule` commands — reads as much as mutations — plus `app versions` and `app set-version` |
-| Answered by Conductor | Everything else except `migrate`: the rest of `app`, plus `api-key`, `permission`, `login`, `logout`, `whoami`, and `config` |
-| Answered by neither | [`migrate`](#dbosctl-migrate), which opens the system database itself |
+| Answered by Conductor | Everything else except `sysdb`: the rest of `app`, plus `api-key`, `permission`, `login`, `logout`, `whoami`, and `config` |
+| Answered by neither | The [`sysdb`](#system-database-commands) commands, which open the system database themselves |
 
 Commands in the first group fail if the application has no healthy executor connected, so a failure there usually means your application is not running rather than that nothing matched.
 
@@ -559,10 +559,29 @@ Lists the permissions that can be granted to an API key or a role.
 
 ## System Database Commands
 
-### `dbosctl migrate`
+`dbosctl sysdb` groups the commands that open a database instead of calling Conductor.
+They connect to a Postgres (or CockroachDB) [system database](../explanations/system-tables.md) directly, so they take a database URL rather than a profile, and accept none of the [common flags](#common-flags) that resolve one.
+
+The system schema is shared by every DBOS SDK and the migrations are built into the `dbosctl` binary, so provisioning and maintaining a system database does not require picking an SDK and installing its toolchain.
+The subcommand names are the ones the Python, TypeScript, and Go CLIs use for the same operations — the grouping is `dbosctl`'s own grammar, which groups by noun everywhere else, not a renaming.
+
+**Shared arguments:**
+- `-D, --db-url <url>`: The system database URL. Overrides `$DBOS_SYSTEM_DATABASE_URL`. Postgres and CockroachDB only — a SQLite system database is migrated by the application process that opens it.
+- `--schema <name>`: The schema holding the DBOS system tables. Defaults to `dbos`.
+
+Both are defined on `sysdb` itself, so every subcommand takes them:
+
+```shell
+dbosctl sysdb migrate -D postgres://user:password@host:5432/dbos_sys
+DBOS_SYSTEM_DATABASE_URL=postgres://user:password@host:5432/dbos_sys dbosctl sysdb migrate
+```
+
+---
+
+### `dbosctl sysdb migrate`
 
 **Description:**
-Creates or upgrades the DBOS [system database](../explanations/system-tables.md).
+Creates or upgrades the DBOS [system database](../explanations/system-tables.md), applying every migration the schema is missing and creating the database and schema if they do not exist yet.
 By default, a DBOS application automatically creates these on startup.
 However, in production environments, a DBOS application may not run with sufficient privilege to create databases or tables.
 In that case, the `migrate` command can be run with a privileged user to create all DBOS database tables.
@@ -570,21 +589,17 @@ In that case, the `migrate` command can be run with a privileged user to create 
 After creating the DBOS database tables with this command, a DBOS application can run with minimum permissions, requiring only access to the DBOS schema in the application and system databases.
 Use the `-r/--app-role` flag to grant a role access to that schema.
 
-The migrations are built into the `dbosctl` binary, and the system schema is shared by every DBOS SDK, so provisioning a database does not require picking an SDK and installing its toolchain.
-The `migrate` command includes an  flag to grant the specified role read/write access to the DBOS schema.
-
-Note, this `dbosctl` command connects to your database instead of Conductor.
-It takes a database URL rather than a profile, and accepts none of the [common flags](#common-flags).
-
-```shell
-dbosctl migrate -D postgres://user:password@host:5432/dbos_sys
-DBOS_SYSTEM_DATABASE_URL=postgres://user:password@host:5432/dbos_sys dbosctl migrate
-```
-
 `migrate` is safe to re-run. Migrations already recorded are skipped, so a database that is up to date is left alone.
 
+**Arguments:**
+- `-r, --app-role <role>`: The role your DBOS application runs as. It is granted the minimum permissions needed to use the DBOS schema.
+- `--no-listen-notify`: Leave out the triggers that fire `pg_notify`. See [LISTEN/NOTIFY](#listennotify) below.
+- `--print-migrations <all|NUMBER>`: Instead of running the migrations, print their SQL to standard output — `all` for a fresh database, or a migration number to upgrade an existing one.
+- `--print-user-role`: Instead of running them, print the SQL statements granting `--app-role` access to the DBOS system tables.
+- `--cockroach`: Render the printed SQL for CockroachDB. Print mode only — see [CockroachDB](#cockroachdb) below.
+
 :::info SDK migration config settings
-After running `dbosctl migrate`, configure your application not to alter the system schema on startup where that option exists:
+After running `dbosctl sysdb migrate`, configure your application not to alter the system schema on startup where that option exists:
 
 <Tabs groupId="language" queryString="language">
 <TabItem value="python" label="Python">
@@ -631,22 +646,13 @@ DBOSConfig config = DBOSConfig.defaults("my-app")
 
 :::
 
-**Arguments:**
-- `-D, --db-url <url>`: The system database URL. Overrides `$DBOS_SYSTEM_DATABASE_URL`. Postgres and CockroachDB only — a SQLite system database is migrated by the application process that opens it.
-- `--schema <name>`: The schema holding the DBOS system tables. Defaults to `dbos`.
-- `-r, --app-role <role>`: The role your DBOS application runs as. It is granted the minimum permissions needed to use the DBOS schema.
-- `--no-listen-notify`: Leave out the triggers that fire `pg_notify`. See [LISTEN/NOTIFY](#listennotify) below.
-- `--print-migrations <all|NUMBER>`: Instead of running the migrations, print their SQL to standard output — `all` for a fresh database, or a migration number to upgrade an existing one.
-- `--print-user-role`: Instead of running them, print the SQL statements granting `--app-role` access to the DBOS system tables.
-- `--cockroach`: Render the printed SQL for CockroachDB. Print mode only — see [CockroachDB](#cockroachdb) below.
-
 #### Printing the SQL
 
 If your database is managed by a DBA, or its DDL goes through review, the print modes emit SQL for someone else to apply:
 
 ```shell
-dbosctl migrate --print-migrations all > migrations.sql
-dbosctl migrate --print-user-role -r my_app_role > grants.sql
+dbosctl sysdb migrate --print-migrations all > migrations.sql
+dbosctl sysdb migrate --print-user-role -r my_app_role > grants.sql
 ```
 
 Neither mode opens the database, and standard output is nothing but SQL and comments, so it can be redirected straight into a `.sql` file.
@@ -664,7 +670,7 @@ That does not work behind a connection pooler in transaction mode: the notificat
 Nothing can detect that, so pass `--no-listen-notify`:
 
 ```shell
-dbosctl migrate -D postgres://user:password@host:5432/dbos_sys --no-listen-notify
+dbosctl sysdb migrate -D postgres://user:password@host:5432/dbos_sys --no-listen-notify
 ```
 
 The database is complete either way and reports the same migration version. Only the triggers differ, and applications fall back to polling.
@@ -676,10 +682,73 @@ A live migration asks the server what it is, so CockroachDB needs no flag; passi
 A printed script has no server to ask, so it has to be told:
 
 ```shell
-dbosctl migrate --print-migrations all --cockroach > migrations.sql
+dbosctl sysdb migrate --print-migrations all --cockroach > migrations.sql
 ```
 
 CockroachDB's script differs in more than the triggers — it has no LISTEN/NOTIFY at all, and several statements are spelled differently or left out — and a script generated for the wrong engine fails partway through, leaving a half-migrated database.
+
+---
+
+### `dbosctl sysdb reset`
+
+**Description:**
+Empties the DBOS system tables, deleting the metadata about past workflows and steps.
+No application data is affected by this.
+
+The schema itself is left migrated and immediately usable, so the database does not have to be provisioned again, and the migration history is kept — clearing it would re-run applied migrations over tables that already exist.
+This is narrower than `dbos reset` in the SDK CLIs, which drop the database outright: `--schema` exists so the DBOS tables can share a database with application tables, and a system database is [shareable between applications](../explanations/sharing-a-system-database.md), so dropping it reaches past what was asked about.
+Only the tables DBOS creates are emptied, so pointing `--schema` at a schema that also holds application tables leaves those alone.
+
+Prompts for confirmation when run interactively.
+
+**Arguments:**
+- `-a, --app <name>`: Empty only this application's rows, for a [shared system database](../explanations/sharing-a-system-database.md). Unlike the common `--app`, this one is read from the command line only — never from `$DBOS_APP` or a profile, since it decides how much of a database to destroy.
+- `--drop-database`: Drop the whole database instead of emptying the DBOS tables. Cannot be combined with `--app` or `--schema`, both of which describe work inside the database it destroys.
+- `--force`: Skip the confirmation prompt. Required when running non-interactively.
+- `-o, --output <format>`: Output format for the row counts — `table` (default) or `json`.
+
+`--app` deletes the rows that name it and lets the foreign keys take the rest: every workflow-keyed table cascades from `workflow_status`, so a workflow's steps, messages, events, and streams go with it.
+Other applications sharing the schema are untouched, and so are rows no application owns.
+
+Per-table row counts are written to standard output, with progress on standard error, so a scripted reset can read what it removed without parsing log lines.
+`--drop-database` prints no counts — the tables go with the database — and neither does a failure, since the deletes are one transaction and a rollback removed nothing.
+
+---
+
+### `dbosctl sysdb rename-application`
+
+**Description:**
+Transfers ownership of everything in the system database — workflows, steps, queues, schedules, and application versions — from an application's old name to its new one.
+An application owns what it creates, keyed by its configured name, so renaming it strands those rows under the old name, where it will not find them. See [Sharing a System Database](../explanations/sharing-a-system-database.md).
+Prints the number of rows transferred, by table.
+**Stop the application being renamed before running this.** Nothing here locks it out, and a running one keeps dequeuing under its old name.
+
+The `rename-app` alias is accepted in place of `rename-application`.
+Prompts for confirmation when run interactively.
+
+**Arguments:**
+- `-f, --from <name>`: The application's previous name. Omit to only adopt unclaimed rows, which then requires `--adopt-unclaimed-rows`.
+- `-t, --to <name>`: The application that ends up owning the rows. Required.
+- `--adopt-unclaimed-rows`: Also transfer rows no application owns (`application_name` is null).
+- `--batch-size <int>`: Completed workflows and steps transferred per transaction. Defaults to 10000.
+- `--force`: Skip the confirmation prompt. Required when running non-interactively.
+- `-o, --output <format>`: Output format for the row counts — `table` (default) or `json`.
+
+Rows no application owns predate system-database sharing, so claiming them is a decision rather than a default: naming neither source is an error rather than a rename that reports moving nothing.
+
+Queues, schedules, versions, and in-flight workflows move in one transaction — a half-owned application would dequeue work whose version row it can no longer see.
+Completed workflows and their steps are unbounded, so they move in batches of `--batch-size` keys, and re-running an interrupted rename picks up where it stopped rather than starting over.
+The counts are rows *durably* transferred: a failure inside the opening transaction reports nothing, because the rollback moved nothing, while a failure in the batched tail reports what committed before it, which is where a re-run picks up.
+
+#### Schema versions
+
+`reset` and `rename-application` both refuse a schema migrated past what your `dbosctl` build knows, and refuse before touching anything.
+The tables they work on are named in the binary rather than read from the catalog, so a migration the build has never seen may have added a table it would silently skip — leaving it full, or leaving its rows under the old name, while reporting success.
+The system schema is shared by every SDK and they release on their own schedules, so meeting a newer database is normal rather than alarming: upgrade `dbosctl`.
+
+`rename-application` also refuses a schema too old for application names, and one part way into them.
+Migrations 100-104 add `application_name` a table at a time, each committing on its own, so a `migrate` interrupted inside that range leaves some tables carrying the column and some not.
+The rename names the tables that are short and tells you to finish migrating, rather than re-owning the ones it can.
 
 ---
 

--- a/docs/production/dbosctl.md
+++ b/docs/production/dbosctl.md
@@ -5,7 +5,7 @@ title: dbosctl CLI Reference
 
 `dbosctl` is a command-line client for the [Conductor API](./conductor-api.md). It manages workflows, queues, schedules, applications, and API keys against DBOS-managed Conductor or a [self-hosted Conductor](./hosting-conductor.md), with the target selected by a named **profile**.
 
-The [`dbosctl sysdb`](#system-database-commands) commands are the exception: they open a Postgres [system database](../explanations/system-tables.md) directly — to migrate it, empty it, or re-own its rows after an application is renamed — so they take a database URL rather than a profile.
+The [`dbosctl sysdb`](#system-database-commands) commands are the exception: they manage the Postgres [system database](../explanations/system-tables.md) directly, so they take a database URL rather than a profile.
 
 ## Installation
 
@@ -563,11 +563,11 @@ Lists the permissions that can be granted to an API key or a role.
 `dbosctl sysdb` groups the commands that open a database instead of calling Conductor.
 They connect to a Postgres (or CockroachDB) [system database](../explanations/system-tables.md) directly, so they take a database URL rather than a profile, and accept none of the [common flags](#common-flags) that resolve one.
 
-The system schema is shared by every DBOS SDK and the migrations are built into the `dbosctl` binary, so provisioning and maintaining a system database does not require picking an SDK and installing its toolchain.
-The subcommand names are the ones the Python, TypeScript, and Go CLIs use for the same operations — the grouping is `dbosctl`'s own grammar, which groups by noun everywhere else, not a renaming.
+The system schema is shared by every DBOS SDK and the migrations are built into the `dbosctl` binary.
+
 
 **Shared arguments:**
-- `-D, --db-url <url>`: The system database URL. Overrides `$DBOS_SYSTEM_DATABASE_URL`. Postgres and CockroachDB only — a SQLite system database is migrated by the application process that opens it.
+- `-D, --db-url <url>`: The system database URL. Overrides `$DBOS_SYSTEM_DATABASE_URL`.
 - `--schema <name>`: The schema holding the DBOS system tables. Defaults to `dbos`.
 
 Both are defined on `sysdb` itself, so every subcommand takes them:
@@ -625,15 +625,6 @@ await DBOS.launch({
 ```
 
 </TabItem>
-<TabItem value="golang" label="Go">
-
-DBOS Go does not expose a `runMigrations` toggle. `NewContext` always checks the DBOS schema and attempts to apply pending migrations. 
-
-If you run your DBOS Go application without DDL permissions against a missing or out-of-data system database,
-it will fail to launch due to denied DDL permissions.
-The application will launch correctly if the database exists and is up-to-date (which the `migrate` command ensures).
-
-</TabItem>
 <TabItem value="java" label="Java">
 
 ```java
@@ -656,110 +647,74 @@ dbosctl sysdb migrate --print-migrations all > migrations.sql
 dbosctl sysdb migrate --print-user-role -r my_app_role > grants.sql
 ```
 
-Neither mode opens the database, and standard output is nothing but SQL and comments, so it can be redirected straight into a `.sql` file.
-If a URL is available the header comment names the database, with the password masked.
-The migrations and the grants are separate scripts, usually run by different people at different times, so asking for both at once is a usage error rather than a concatenation.
-
-The generated SQL contains `CREATE INDEX CONCURRENTLY` and `DROP INDEX CONCURRENTLY`, so it must run outside a transaction block — plain `psql`, not `psql --single-transaction`.
-The header comment records that, along with the choices that shaped the script: whether it is for a fresh database, whether the `pg_notify` triggers are included, and whether it is for CockroachDB.
-Nothing downstream can tell those variants apart by reading the SQL, and applying the wrong one leaves a database that does not match what your applications expect.
-
 #### LISTEN/NOTIFY
 
-By default the system schema carries triggers that fire `pg_notify`, so an application waiting on a message is woken rather than left to poll.
-That does not work behind a connection pooler in transaction mode: the notification arrives on a session the application does not keep.
-Nothing can detect that, so pass `--no-listen-notify`:
+If your system database sites behind a connection pooler in transaction mode, pass `--no-listen-notify` to generate a system scehma that doesn't use `pg_notify`.:
 
 ```shell
 dbosctl sysdb migrate -D postgres://user:password@host:5432/dbos_sys --no-listen-notify
 ```
 
-The database is complete either way and reports the same migration version. Only the triggers differ, and applications fall back to polling.
-A pooler in session mode needs no flag — see the [production checklist](./checklist.md).
-
 #### CockroachDB
 
-A live migration asks the server what it is, so CockroachDB needs no flag; passing `--cockroach` to one is an error rather than an override.
-A printed script has no server to ask, so it has to be told:
+Live migration can detect when the system database is running on CockroachDB.
+Since a printed script cannot detect the database engine, use `--cockroach` to specify Cockroach compatible system database migrations.
 
 ```shell
 dbosctl sysdb migrate --print-migrations all --cockroach > migrations.sql
 ```
-
-CockroachDB's script differs in more than the triggers — it has no LISTEN/NOTIFY at all, and several statements are spelled differently or left out — and a script generated for the wrong engine fails partway through, leaving a half-migrated database.
 
 ---
 
 ### `dbosctl sysdb reset`
 
 **Description:**
-Empties the DBOS system tables, deleting the metadata about past workflows and steps.
-No application data is affected by this.
+Empties the DBOS system database, deleting all the rows in the DBOS system tables.
 
-The schema itself is left migrated and immediately usable, so the database does not have to be provisioned again, and the migration history is kept — clearing it would re-run applied migrations over tables that already exist.
-This is narrower than `dbos reset` in the SDK CLIs, which drop the database outright: `--schema` exists so the DBOS tables can share a database with application tables, and a system database is [shareable between applications](../explanations/sharing-a-system-database.md), so dropping it reaches past what was asked about.
-Only the tables DBOS creates are emptied, so pointing `--schema` at a schema that also holds application tables leaves those alone.
+The schema itself is left migrated and immediately usable, so the database does not have to be provisioned again.
 
 Prompts for confirmation when run interactively.
 
 **Arguments:**
-- `-a, --app <name>`: Empty only this application's rows, for a [shared system database](../explanations/sharing-a-system-database.md). Unlike the common `--app`, this one is read from the command line only — never from `$DBOS_APP` or a profile, since it decides how much of a database to destroy.
-- `--drop-database`: Drop the whole database instead of emptying the DBOS tables. Cannot be combined with `--app` or `--schema`, both of which describe work inside the database it destroys.
+- `-a, --app <name>`: Empty only the specified application's rows, for a [shared system database](../explanations/sharing-a-system-database.md). Unlike the `--app` argument used by Conductor commands, this argument is only read from the command line — never from `$DBOS_APP` or a profile.
+- `--drop-database`: Drop the whole database instead of emptying the DBOS tables. Cannot be combined with `--app` or `--schema`.
 - `--force`: Skip the confirmation prompt. Required when running non-interactively.
 - `-o, --output <format>`: Output format for the row counts — `table` (default) or `json`.
 
-`--app` deletes the rows that name it and lets the foreign keys take the rest: every workflow-keyed table cascades from `workflow_status`, so a workflow's steps, messages, events, and streams go with it.
-Other applications sharing the schema are untouched, and so are rows no application owns.
-
-Per-table row counts are written to standard output, with progress on standard error, so a scripted reset can read what it removed without parsing log lines.
-`--drop-database` prints no counts — the tables go with the database — and neither does a failure, since the deletes are one transaction and a rollback removed nothing.
+When not using `--drop-database`, per-table row counts are written to standard output, with progress on standard error, so a scripted reset can read what it removed without parsing log lines.
 
 ---
 
 ### `dbosctl sysdb rename-application`
 
 **Description:**
-Transfers ownership of everything in the system database — workflows, steps, queues, schedules, and application versions — from an application's old name to its new one.
-An application owns what it creates, keyed by its configured name, so renaming it strands those rows under the old name, where it will not find them. See [Sharing a System Database](../explanations/sharing-a-system-database.md).
-Prints the number of rows transferred, by table.
-**Stop the application being renamed before running this.** Nothing here locks it out, and a running one keeps dequeuing under its old name.
-
+Transfers ownership of everything in the system database from an application's old name to its new one.
 The `rename-app` alias is accepted in place of `rename-application`.
+Prints the number of rows transferred, by table.
 Prompts for confirmation when run interactively.
+
+:::warning
+**Stop the application being renamed before running this.** Nothing here locks it out, and a running one keeps creating new records using its old name.
+:::
 
 **Arguments:**
 - `-f, --from <name>`: The application's previous name. Omit to only adopt unclaimed rows, which then requires `--adopt-unclaimed-rows`.
-- `-t, --to <name>`: The application that ends up owning the rows. Required.
+- `-t, --to <name>`: The application that ends up owning the rows. Required. Must not be only whitespace.
 - `--adopt-unclaimed-rows`: Also transfer rows no application owns (`application_name` is null).
 - `--batch-size <int>`: Completed workflows and steps transferred per transaction. Defaults to 10000.
 - `--force`: Skip the confirmation prompt and the `--to` name checks. Required when running non-interactively.
 - `-o, --output <format>`: Output format for the row counts — `table` (default) or `json`.
 
-Rows no application owns predate system-database sharing, so claiming them is a decision rather than a default: naming neither source is an error rather than a rename that reports moving nothing.
-
-`--to` is looked at before anything moves.
-A name that is only whitespace is refused outright — no application can be configured with it, so the rename would move a whole history somewhere nothing will look for it again.
-Two others are reported above the confirmation prompt and asked about rather than refused:
-
-- A name outside `^[a-z0-9-_]{3,30}$`. DBOS Transact places no limits on an application name, but DBOS Conductor and Cloud do: a name that does not match cannot be registered or used with either.
-- A name that already owns rows in the schema. Merging two applications is a real thing to want, and it is what `--to` alone with `--adopt-unclaimed-rows` does on purpose.
-
-Each is also exactly what the corresponding mistake looks like — a stray capital or space, and a `--to` naming the wrong existing application — and nothing here can tell the two apart, so the answer to the prompt decides them.
-`--force` skips that prompt and both questions with it, including the query that asks the database whether the name is already taken.
-
-Queues, schedules, versions, and in-flight workflows move in one transaction — a half-owned application would dequeue work whose version row it can no longer see.
-Completed workflows and their steps are unbounded, so they move in batches of `--batch-size` keys, and re-running an interrupted rename picks up where it stopped rather than starting over.
-The counts are rows *durably* transferred: a failure inside the opening transaction reports nothing, because the rollback moved nothing, while a failure in the batched tail reports what committed before it, which is where a re-run picks up.
+By default, `rename-application` expects the `--to` name to unsused and to be DBOS Conductor compatible (between 3 and 30 characters, only numvers, lower case ASCII leters, hyphen and underscore).
+For interactive shells, `rename-application` will confirm with the user before renaming if either of these conditions are false.
+This check can be overridden with the `--force` argument.
 
 #### Schema versions
 
-`reset` and `rename-application` both refuse a schema migrated past what your `dbosctl` build knows, and refuse before touching anything.
-The tables they work on are named in the binary rather than read from the catalog, so a migration the build has never seen may have added a table it would silently skip — leaving it full, or leaving its rows under the old name, while reporting success.
-The system schema is shared by every SDK and they release on their own schedules, so meeting a newer database is normal rather than alarming: upgrade `dbosctl`.
+`reset` and `rename-application` both refuse a schema migrated past what your `dbosctl` version knows.
+Typically, in this case you just need to install a more recent version of `dbosctl`.
 
-`rename-application` also refuses a schema too old for application names, and one part way into them.
-Migrations 100-104 add `application_name` a table at a time, each committing on its own, so a `migrate` interrupted inside that range leaves some tables carrying the column and some not.
-The rename names the tables that are short and tells you to finish migrating, rather than re-owning the ones it can.
+`rename-application` also refuses a schema that predates the addition of application names.
 
 ---
 

--- a/docs/production/dbosctl.md
+++ b/docs/production/dbosctl.md
@@ -5,6 +5,8 @@ title: dbosctl CLI Reference
 
 `dbosctl` is a command-line client for the [Conductor API](./conductor-api.md). It manages workflows, queues, schedules, applications, and API keys against DBOS-managed Conductor or a [self-hosted Conductor](./hosting-conductor.md), with the target selected by a named **profile**.
 
+[`dbosctl migrate`](#dbosctl-migrate) is the exception: it opens a Postgres [system database](../explanations/system-tables.md) directly to create or upgrade the DBOS schema, so it takes a database URL rather than a profile.
+
 ## Installation
 
 The install script detects your platform, verifies the download against the release checksums, and installs `dbosctl` to the first writable of `/usr/local/bin`, `~/.local/bin`, or the current directory:
@@ -104,6 +106,7 @@ Each setting is resolved **flag → environment variable → profile**, so a fla
 | Organization | `--org` | `DBOS_ORG` |
 | Application | `-a`, `--app` | `DBOS_APP` |
 | Bearer token | — | `DBOS_TOKEN` |
+| System database ([`migrate`](#dbosctl-migrate) only) | `-D`, `--db-url` | `DBOS_SYSTEM_DATABASE_URL` |
 | Output format | `-o`, `--output` | — |
 
 Flags are scoped to the command that uses them, so pass them **after** the command name (`dbosctl app list --org acme`). Each command's `--help` lists only the flags it honors.
@@ -117,6 +120,8 @@ These flags are accepted by most commands and are not repeated in the reference 
 - `--org <name>`: Organization. Overrides `$DBOS_ORG` and the profile.
 - `-a, --app <name>`: Application name, for application-scoped commands. Overrides `$DBOS_APP` and the profile.
 - `-o, --output <format>`: Output format — `table` (default), `json`, or `ids`.
+
+[`dbosctl migrate`](#dbosctl-migrate) accepts none of them. It does not talk to Conductor, so there is no profile, organization, or application to name, and what it writes is progress text or SQL rather than a formatted result.
 
 ## Output
 
@@ -154,7 +159,8 @@ Conductor answers some commands itself and forwards the rest to your application
 | | Commands |
 | --- | --- |
 | Forwarded to your application | All `workflow`, `queue`, and `schedule` commands — reads as much as mutations — plus `app versions` and `app set-version` |
-| Answered by Conductor | Everything else: the rest of `app`, plus `api-key`, `permission`, `login`, `logout`, `whoami`, and `config` |
+| Answered by Conductor | Everything else except `migrate`: the rest of `app`, plus `api-key`, `permission`, `login`, `logout`, `whoami`, and `config` |
+| Answered by neither | [`migrate`](#dbosctl-migrate), which opens the system database itself |
 
 Commands in the first group fail if the application has no healthy executor connected, so a failure there usually means your application is not running rather than that nothing matched.
 
@@ -548,6 +554,79 @@ Deletes an API key, revoking it immediately.
 
 **Description:**
 Lists the permissions that can be granted to an API key or a role.
+
+---
+
+## System Database Commands
+
+### `dbosctl migrate`
+
+**Description:**
+Creates or upgrades the DBOS [system database](../explanations/system-tables.md), applying every migration its schema is missing and creating the database and the schema if they do not exist yet.
+
+By default a DBOS application creates and upgrades these tables itself on startup.
+In production it often cannot: the role it runs as has no privilege to create databases or tables.
+Run `migrate` with a privileged role first, and the application can then run with access to the DBOS schema alone — grant it with `-r/--app-role`, and configure the application not to run migrations itself, so that it verifies the schema at launch rather than altering it.
+
+The migrations are built into the binary, and the system schema is shared by every DBOS SDK, so provisioning a database does not mean picking an SDK and installing its toolchain.
+This is the only `dbosctl` command that opens a database: it takes a database URL rather than a profile, and accepts none of the [common flags](#common-flags).
+
+It is safe to re-run. Migrations already recorded are skipped, so a database that is up to date is left alone.
+
+```shell
+dbosctl migrate -D postgres://user:password@host:5432/dbos_sys
+DBOS_SYSTEM_DATABASE_URL=postgres://user:password@host:5432/dbos_sys dbosctl migrate
+```
+
+**Arguments:**
+- `-D, --db-url <url>`: The system database URL. Overrides `$DBOS_SYSTEM_DATABASE_URL`. Postgres and CockroachDB only — a SQLite system database is migrated by the application process that opens it.
+- `--schema <name>`: The schema holding the DBOS system tables. Defaults to `dbos`.
+- `-r, --app-role <role>`: The role your DBOS application runs as. It is granted the minimum permissions needed to use the DBOS schema.
+- `--no-listen-notify`: Leave out the triggers that fire `pg_notify`. See [LISTEN/NOTIFY](#listennotify) below.
+- `--print-migrations <all|NUMBER>`: Instead of running the migrations, print their SQL to standard output — `all` for a fresh database, or a migration number to upgrade an existing one.
+- `--print-user-role`: Instead of running them, print the SQL statements granting `--app-role` access to the DBOS system tables.
+- `--cockroach`: Render the printed SQL for CockroachDB. Print mode only — see [CockroachDB](#cockroachdb) below.
+
+#### Printing the SQL
+
+If your database is managed by a DBA, or its DDL goes through review, the print modes emit SQL for someone else to apply:
+
+```shell
+dbosctl migrate --print-migrations all > migrations.sql
+dbosctl migrate --print-user-role -r my_app_role > grants.sql
+```
+
+Neither mode opens the database, and standard output is nothing but SQL and comments, so it can be redirected straight into a `.sql` file.
+If a URL is available the header comment names the database, with the password masked.
+The migrations and the grants are separate scripts, usually run by different people at different times, so asking for both at once is a usage error rather than a concatenation.
+
+The generated SQL contains `CREATE INDEX CONCURRENTLY` and `DROP INDEX CONCURRENTLY`, so it must run outside a transaction block — plain `psql`, not `psql --single-transaction`.
+The header comment records that, along with the choices that shaped the script: whether it is for a fresh database, whether the `pg_notify` triggers are included, and whether it is for CockroachDB.
+Nothing downstream can tell those variants apart by reading the SQL, and applying the wrong one leaves a database that does not match what your applications expect.
+
+#### LISTEN/NOTIFY
+
+By default the system schema carries triggers that fire `pg_notify`, so an application waiting on a message is woken rather than left to poll.
+That does not work behind a connection pooler in transaction mode: the notification arrives on a session the application does not keep.
+Nothing can detect that, so pass `--no-listen-notify`:
+
+```shell
+dbosctl migrate -D postgres://user:password@host:5432/dbos_sys --no-listen-notify
+```
+
+The database is complete either way and reports the same migration version. Only the triggers differ, and applications fall back to polling.
+A pooler in session mode needs no flag — see the [production checklist](./checklist.md).
+
+#### CockroachDB
+
+A live migration asks the server what it is, so CockroachDB needs no flag; passing `--cockroach` to one is an error rather than an override.
+A printed script has no server to ask, so it has to be told:
+
+```shell
+dbosctl migrate --print-migrations all --cockroach > migrations.sql
+```
+
+CockroachDB's script differs in more than the triggers — it has no LISTEN/NOTIFY at all, and several statements are spelled differently or left out — and a script generated for the wrong engine fails partway through, leaving a half-migrated database.
 
 ---
 

--- a/docs/production/hosting-with-cloud-run.md
+++ b/docs/production/hosting-with-cloud-run.md
@@ -49,7 +49,7 @@ Deploying a DBOS application to Cloud Run is no different from deploying any oth
 The one DBOS-specific detail is the **database connection string**: it must be provided in `key=value` format (e.g., `user=postgres password=secret database=myappdb host=/cloudsql/...`). On Cloud Run, use the `--add-cloudsql-instances` flag to mount the [Cloud SQL Auth Proxy](https://cloud.google.com/sql/docs/postgres/connect-run) Unix socket, then pass the socket path as the `host` parameter. This gives your app a private, encrypted path to the database with no public IP.
 
 :::tip Schema migration
-By default, DBOS creates its [system tables](../explanations/system-tables.md) on startup. If your Cloud Run service account doesn't have DDL privileges, run [`dbos migrate`](../golang/reference/cli.md) with a privileged user before deploying.
+By default, DBOS creates its [system tables](../explanations/system-tables.md) on startup. If your Cloud Run service account doesn't have DDL privileges, run [`dbosctl migrate`](./dbosctl.md#dbosctl-migrate) with a privileged user before deploying.
 :::
 
 <details>

--- a/docs/production/hosting-with-cloud-run.md
+++ b/docs/production/hosting-with-cloud-run.md
@@ -49,7 +49,7 @@ Deploying a DBOS application to Cloud Run is no different from deploying any oth
 The one DBOS-specific detail is the **database connection string**: it must be provided in `key=value` format (e.g., `user=postgres password=secret database=myappdb host=/cloudsql/...`). On Cloud Run, use the `--add-cloudsql-instances` flag to mount the [Cloud SQL Auth Proxy](https://cloud.google.com/sql/docs/postgres/connect-run) Unix socket, then pass the socket path as the `host` parameter. This gives your app a private, encrypted path to the database with no public IP.
 
 :::tip Schema migration
-By default, DBOS creates its [system tables](../explanations/system-tables.md) on startup. If your Cloud Run service account doesn't have DDL privileges, run [`dbosctl migrate`](./dbosctl.md#dbosctl-migrate) with a privileged user before deploying.
+By default, DBOS creates its [system tables](../explanations/system-tables.md) on startup. If your Cloud Run service account doesn't have DDL privileges, run [`dbosctl sysdb migrate`](./dbosctl.md#dbosctl-sysdb-migrate) with a privileged user before deploying.
 :::
 
 <details>

--- a/docs/production/hosting-with-kubernetes.md
+++ b/docs/production/hosting-with-kubernetes.md
@@ -299,7 +299,7 @@ sleep 15 && kubectl logs pg-setup -n dbos && kubectl delete pod pg-setup -n dbos
 
 This creates:
 - `dbos_app` — the application's system database for workflow state
-- `dbos_app_role` — a restricted role the application uses at runtime (granted permissions by `dbos migrate`)
+- `dbos_app_role` — a restricted role the application uses at runtime (granted permissions by `dbosctl migrate`)
 
 </details>
 
@@ -437,7 +437,7 @@ postgres-admin      Opaque   2      10s
 
 DBOS applications store workflow state in [system tables](../explanations/system-tables.md).
 These tables must be created before the application can start.
-We use a separate Kubernetes Job that runs `dbos migrate` with **admin** credentials, then the application itself runs with a **restricted** role that can only read/write data — not modify schema.
+We use a separate Kubernetes Job that runs [`dbosctl migrate`](./dbosctl.md#dbosctl-migrate) with **admin** credentials, then the application itself runs with a **restricted** role that can only read/write data — not modify schema.
 
 This separation follows the principle of least privilege: the application never holds the keys to alter its own schema.
 
@@ -445,17 +445,20 @@ This separation follows the principle of least privilege: the application never 
 
 <summary><strong>Migration image and build</strong></summary>
 
-The migration image contains only the DBOS CLI — it doesn't include your application code.
+The migration image contains only `dbosctl` — it doesn't include your application code, or a toolchain for the language that code is written in.
+`dbosctl` ships as a statically linked release binary carrying the migrations, so the image is a download rather than a build:
 
 ```dockerfile title="Dockerfile.migrate"
-FROM golang:1.25-alpine AS builder
-RUN CGO_ENABLED=0 GOOS=linux go install github.com/dbos-inc/dbos-transact-golang/cmd/dbos@latest
-
 FROM alpine:latest
-RUN apk --no-cache add ca-certificates
-COPY --from=builder /go/bin/dbos /usr/local/bin/dbos
-ENTRYPOINT ["dbos"]
+# Pin this to the dbosctl release you have tested; leave it empty for the latest.
+ARG DBOSCTL_VERSION=""
+RUN apk --no-cache add ca-certificates curl
+RUN curl -sSfL https://raw.githubusercontent.com/dbos-inc/dbos-ctl/main/install.sh \
+  | VERSION="${DBOSCTL_VERSION}" BIN_DIR=/usr/local/bin sh
+ENTRYPOINT ["dbosctl"]
 ```
+
+Pin `DBOSCTL_VERSION` for a pipeline you want to be reproducible: an unpinned build takes whatever the latest release is on the day it runs, which is not what you tested.
 
 ```bash
 # Set your ECR repository URI
@@ -472,7 +475,7 @@ docker push ${ECR_MIGRATE}:latest
 
 </details>
 
-The Job runs `dbos migrate --app-role dbos_app_role`, which:
+The Job runs `dbosctl migrate --app-role dbos_app_role`, which:
 1. Creates the DBOS system tables in the `dbos_app` database (if they don't exist)
 2. Applies any pending schema migrations
 3. Grants the necessary permissions to `dbos_app_role` so the application can read and write workflow state
@@ -508,7 +511,7 @@ spec:
 ```
 
 The `postgres-admin` secret contains the admin connection string, which has the privileges needed to create tables and grant permissions.
-The `--app-role` flag tells `dbos migrate` to grant the specified role access to the system tables.
+The `--app-role` flag tells `dbosctl migrate` to grant the specified role access to the system tables.
 
 </details>
 
@@ -537,7 +540,8 @@ kubectl logs -n dbos job/dbos-migrate
 
 **Re-running Migrations**
 
-When you deploy a new version of the DBOS SDK that includes schema changes, re-run the migration job.
+When a new `dbosctl` release adds migrations — usually alongside a DBOS SDK version that expects them — rebuild the migration image against that release and re-run the Job.
+Re-running a Job built from the same pinned release is harmless but does nothing: `dbosctl migrate` skips migrations that are already recorded.
 Since Kubernetes Job names must be unique, delete the old job first:
 
 ```bash

--- a/docs/production/hosting-with-kubernetes.md
+++ b/docs/production/hosting-with-kubernetes.md
@@ -33,9 +33,9 @@ When Conductor is in a different cluster, use `wss://` so the WebSocket connecti
 DBOS applications store workflow state in [system tables](../explanations/system-tables.md).
 These tables must be created before the application can start.
 
-Run [`dbosctl migrate`](./dbosctl.md#dbosctl-migrate) with an **admin** role that can create schema and grant permissions, and run the application with a **restricted** role that can only read/write data. Use the `--app-role` flag to grant the necessary schema permissions to the restricted role.
+Run [`dbosctl sysdb migrate`](./dbosctl.md#dbosctl-sysdb-migrate) with an **admin** role that can create schema and grant permissions, and run the application with a **restricted** role that can only read/write data. Use the `--app-role` flag to grant the necessary schema permissions to the restricted role.
 
-`dbosctl migrate` works well as a Kubernetes [Job](https://kubernetes.io/docs/concepts/workloads/controllers/job/) that you compose into your CI/CD pipeline. It is a single static binary carrying the migrations, so the Job needs no SDK toolchain and no copy of your application.
+`dbosctl sysdb migrate` works well as a Kubernetes [Job](https://kubernetes.io/docs/concepts/workloads/controllers/job/) that you compose into your CI/CD pipeline. It is a single static binary carrying the migrations, so the Job needs no SDK toolchain and no copy of your application.
 
 ## Availability
 
@@ -299,7 +299,7 @@ sleep 15 && kubectl logs pg-setup -n dbos && kubectl delete pod pg-setup -n dbos
 
 This creates:
 - `dbos_app` — the application's system database for workflow state
-- `dbos_app_role` — a restricted role the application uses at runtime (granted permissions by `dbosctl migrate`)
+- `dbos_app_role` — a restricted role the application uses at runtime (granted permissions by `dbosctl sysdb migrate`)
 
 </details>
 
@@ -437,7 +437,7 @@ postgres-admin      Opaque   2      10s
 
 DBOS applications store workflow state in [system tables](../explanations/system-tables.md).
 These tables must be created before the application can start.
-We use a separate Kubernetes Job that runs [`dbosctl migrate`](./dbosctl.md#dbosctl-migrate) with **admin** credentials, then the application itself runs with a **restricted** role that can only read/write data — not modify schema.
+We use a separate Kubernetes Job that runs [`dbosctl sysdb migrate`](./dbosctl.md#dbosctl-sysdb-migrate) with **admin** credentials, then the application itself runs with a **restricted** role that can only read/write data — not modify schema.
 
 This separation follows the principle of least privilege: the application never holds the keys to alter its own schema.
 
@@ -475,7 +475,7 @@ docker push ${ECR_MIGRATE}:latest
 
 </details>
 
-The Job runs `dbosctl migrate --app-role dbos_app_role`, which:
+The Job runs `dbosctl sysdb migrate --app-role dbos_app_role`, which:
 1. Creates the DBOS system tables in the `dbos_app` database (if they don't exist)
 2. Applies any pending schema migrations
 3. Grants the necessary permissions to `dbos_app_role` so the application can read and write workflow state
@@ -499,6 +499,7 @@ spec:
         - name: migrate
           image: ${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_REGION}.amazonaws.com/dbos-migrate:latest
           args:
+            - "sysdb"
             - "migrate"
             - "--app-role"
             - "dbos_app_role"
@@ -511,7 +512,7 @@ spec:
 ```
 
 The `postgres-admin` secret contains the admin connection string, which has the privileges needed to create tables and grant permissions.
-The `--app-role` flag tells `dbosctl migrate` to grant the specified role access to the system tables.
+The `--app-role` flag tells `dbosctl sysdb migrate` to grant the specified role access to the system tables.
 
 </details>
 
@@ -541,7 +542,7 @@ kubectl logs -n dbos job/dbos-migrate
 **Re-running Migrations**
 
 When a new `dbosctl` release adds migrations — usually alongside a DBOS SDK version that expects them — rebuild the migration image against that release and re-run the Job.
-Re-running a Job built from the same pinned release is harmless but does nothing: `dbosctl migrate` skips migrations that are already recorded.
+Re-running a Job built from the same pinned release is harmless but does nothing: `dbosctl sysdb migrate` skips migrations that are already recorded.
 Since Kubernetes Job names must be unique, delete the old job first:
 
 ```bash

--- a/docs/production/hosting-with-kubernetes.md
+++ b/docs/production/hosting-with-kubernetes.md
@@ -33,9 +33,9 @@ When Conductor is in a different cluster, use `wss://` so the WebSocket connecti
 DBOS applications store workflow state in [system tables](../explanations/system-tables.md).
 These tables must be created before the application can start.
 
-Run `dbos migrate` ([Python](../python/reference/cli.md#dbos-migrate), [Go](../golang/reference/cli.md)) or `dbos schema` ([TypeScript](../typescript/reference/cli.md#npx-dbos-schema)) with an **admin** role that can create schema and grant permissions, and run the application with a **restricted** role that can only read/write data. Use the `--app-role` flag to grant the necessary schema permissions to the restricted role.
+Run [`dbosctl migrate`](./dbosctl.md#dbosctl-migrate) with an **admin** role that can create schema and grant permissions, and run the application with a **restricted** role that can only read/write data. Use the `--app-role` flag to grant the necessary schema permissions to the restricted role.
 
-`dbos migrate` works well as a Kubernetes [Job](https://kubernetes.io/docs/concepts/workloads/controllers/job/) that you compose into your CI/CD pipeline.
+`dbosctl migrate` works well as a Kubernetes [Job](https://kubernetes.io/docs/concepts/workloads/controllers/job/) that you compose into your CI/CD pipeline. It is a single static binary carrying the migrations, so the Job needs no SDK toolchain and no copy of your application.
 
 ## Availability
 


### PR DESCRIPTION
`dbosctl` grew a group of commands that open a DBOS system database directly rather than calling Conductor ([dbos-ctl#13](https://github.com/dbos-inc/dbos-ctl/pull/13) and [#14](https://github.com/dbos-inc/dbos-ctl/pull/14), both merged): `sysdb migrate`, `sysdb reset`, and `sysdb rename-application`. This documents them, and points the guides that used to name a language's own CLI at them instead.

## Reference

A new **System Database Commands** section in `production/dbosctl.md` covering the `sysdb` group. The group intro explains why these commands are different in kind — they connect to Postgres (or CockroachDB) directly, take a database URL rather than a profile, and accept none of the common flags that resolve one — and documents `-D/--db-url` and `--schema` once, since they are persistent flags on the group.

- **`sysdb migrate`** — the privileged-provisioning-then-`--app-role` story, the full flag list, and three subsections: printing the SQL for a database whose DDL goes through review, `--no-listen-notify` for a pooler in transaction mode, and `--cockroach` for a printed script that has no server to interrogate.
- **`sysdb reset`** — empties the DBOS tables and leaves the schema migrated, which is narrower than the SDK CLIs' `dbos reset`, so the entry says why, along with `--app` for a shared system database, the cascade from `workflow_status`, and `--drop-database` for the blunt version.
- **`sysdb rename-application`** — the `rename-app` alias, the "stop the application first" warning, the one-transaction/batched-tail split, and what the printed counts mean when a run fails partway.
- A **Schema versions** subsection covering the guard `reset` and `rename-application` share: they refuse a schema migrated past what the binary knows, since a table it has never seen is one it would silently skip.

The `sysdb` group breaks the page's premise that every command goes through Conductor, so the intro, the precedence table, the common-flags list, and the table of what Conductor forwards each note the exception. `reset` and `rename-application` do print row counts, so the common-flags note records that they honor `-o` (`table` or `json`, not `ids`).

Also in the reference, unrelated to `sysdb`: `app register` grew `--private-mode` ([dbos-ctl#16](https://github.com/dbos-inc/dbos-ctl/pull/16)), and the description `app update` carried for the same flag was wrong — private mode keeps workflow payload data out of Conductor, it does not restrict who can see the application ([dbos-ctl#15](https://github.com/dbos-inc/dbos-ctl/pull/15)).

## Production guides

Several places told the reader to provision or reset a system database with an SDK's CLI. None of them is about a language:

- **`checklist.md`** forked three ways (`dbos migrate` in Python or Go, `dbos schema` in TypeScript) to say one thing.
- **`faq.md`** did the same twice for provisioning, and again for the development-reset answer, which now names `dbosctl sysdb reset` — a better fit for that question either way, since it leaves the schema migrated and the next run does not have to provision the database again.
- **`hosting-with-cloud-run.md`** linked `dbos migrate` to the Go reference alone, so a Python or TypeScript reader landed in the wrong SDK's docs.
- **`hosting-with-kubernetes.md`** had the same three-way fork, and built its migration-Job image with a two-stage Go build — `go install` of the Go SDK's CLI on `golang:1.25-alpine`. That is a Go toolchain in the pipeline of an application that need not be written in Go. `dbosctl` ships a statically linked release binary, so the image is now a download onto `alpine`, with the release as a build arg.
- **`explanations/sharing-a-system-database.md`** pointed renaming at each language's own command. A system database shared by applications in different languages is not any one language's to manage, so it now reaches for `dbosctl sysdb rename-application`, with the SDK commands still listed for the single-language case.

## Notes for review

- **The gate is a release, not a merge.** [dbos-ctl#13](https://github.com/dbos-inc/dbos-ctl/pull/13), [#14](https://github.com/dbos-inc/dbos-ctl/pull/14), and [#16](https://github.com/dbos-inc/dbos-ctl/pull/16) have all merged, and these pages match the merged commands. But the latest `dbosctl` is still [v0.9.0](https://github.com/dbos-inc/dbos-ctl/releases/tag/v0.9.0) (2026-08-19), which predates all three, so `install.sh` installs a binary with no `sysdb` command at all. These pages tell people to run one, so they should not go live until a release carries it.
- The Kubernetes `Dockerfile.migrate` is still **untested**, for the same reason: building it needs a published release containing the commands, and an unpinned build currently installs v0.9.0. It uses `curl` rather than Alpine's busybox `wget`, since busybox HTTPS depends on `ssl_client` being present, and it matches the install command already documented on the page.
- The Job manifest's args now carry the group (`sysdb`, `migrate`, `--app-role`, …); `DBOS_SYSTEM_DATABASE_URL` is unchanged.
- Pinning the migration image moved what triggers a re-run, so the "Re-running Migrations" note changed with it: a new `dbosctl` release, not a new SDK version, and the image must be rebuilt first.
- The **application** image in the Kubernetes guide still builds from `golang:1.25-alpine`. That one does contain the sample application, and it is written in Go.
- The per-language reference pages are untouched. Each SDK still ships `migrate`, `reset`, and `rename-application` for its own language, and those pages are where they belong; this PR only changes the cross-cutting guides, which had to pick a language to name and should not have to.
- `dbos-cloud` commands and `dbos start` are untouched — a different CLI, and a genuinely per-language one.

## Testing

`npm run build` passes on each commit. All new anchors resolve. The one broken-anchor warning (`#handling-non-checkpointed-errors` in the Go reference) is pre-existing on `main` and unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
