### PR TITLE
Apply missed review suggestions from #617

### DIFF
--- a/docs/production/conductor-api.md
+++ b/docs/production/conductor-api.md
@@ -226,7 +226,6 @@ The response contains the key's secret. It is returned **once**, at creation, an
 | List metrics | `GET /v2/orgs/{orgName}/apps/{appName}/metrics` |
 
 `PATCH .../apps/{appName}` is where an application's tuning settings live: the executor timeout, the global workflow timeout, the [workflow retention thresholds](./retention.md), and private mode.
-Retention is opt-in: a new application has no thresholds set and no history is deleted until you set one. Pass a negative value to clear a threshold.
 
 :::info
 `GET .../metrics` returns metrics for one application over a time window. If you want to scrape Conductor from Prometheus, Datadog, or Grafana, use the OpenMetrics endpoint described in [Metrics](./metrics.md) instead.

--- a/docs/production/dbosctl.md
+++ b/docs/production/dbosctl.md
@@ -275,8 +275,6 @@ Updates an application's tuning settings. Only the flags you pass are changed.
 - `--global-timeout-ms <int>`: Global workflow timeout, in milliseconds.
 - `--gc-rows-threshold <int>`: Workflow rows kept before garbage collection. See [Workflow Retention Policies](./retention.md).
 - `--gc-time-threshold-ms <int>`: Age, in milliseconds, before a workflow is garbage-collected.
-
-Retention is opt-in: neither threshold is set on a new application, so no history is deleted until you set one. Pass a negative value to clear a threshold.
 - `--private-mode`: Whether the application is in private mode, in which it does not send workflow payload data — inputs, outputs, and events — to Conductor. Pass `--private-mode=false` to turn it back off.
 
 ---

--- a/docs/production/retention.md
+++ b/docs/production/retention.md
@@ -6,8 +6,6 @@ title: Workflow Retention Policies
 If you are using [Conductor](./conductor.md), you can configure workflow history retention policies for your application from the Retention Policy page of the DBOS Console.
 These settings let you configure how long workflow history is retained in your application's [system database](../explanations/system-tables.md).
 This is useful for managing the database disk usage of workflow history.
-Retention is **opt-in**: by default, no policy is set and Conductor never deletes workflow history or cancels workflows.
-Nothing runs for an application until you set at least one of the thresholds below.
 If multiple applications [share a system database](../explanations/sharing-a-system-database.md), each application's retention policies and global timeout apply only to workflow history it owns.
 
 <img src={require('@site/static/img/retention/retention-conductor.png').default} alt="Retention Page" width="1000" className="custom-img" />
@@ -23,7 +21,6 @@ Time-based retention is disabled by default.
 If the rows threshold is set, history is only retained for the last X completed workflows.
 History of additional completed workflows is automatically deleted.
 Rows-based retention is disabled by default.
-Applications created before retention became opt-in keep the rows threshold they already had (formerly 1,000,000 rows by default); clear it from the Retention Policy page to disable it.
 You can set both a rows threshold and a time threshold.
 
 ### Global Timeout


### PR DESCRIPTION
Removes the retention opt-in sentences in `retention.md`, `dbosctl.md`, and `conductor-api.md` that were flagged for deletion in the review of #617 but not applied before it merged.